### PR TITLE
Enhance mqtop with interactive single-table view

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,9 @@ Non-microbiome group jobs / CPU: 0 / 0 (0.0%)
 ```
 
 For an interactive view of job status, use `mqtop`. Navigate with the arrow
-keys or `j`/`k`, press `l` or `o` to view a job's stdout log, `e` for stderr,
-and `r` to refresh the display. This command replaces the old
+keys or `j`/`k`, or select rows with the mouse. Press `/` to search by job name
+or ID, `l` or `o` to view a job's stdout log, `e` for stderr, and `r` to refresh
+the display. A help footer summarises these keys. This command replaces the old
 `mqstat --watch` option.
 
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:

--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ sternesp CPUs queued: 0
 Non-microbiome group jobs / CPU: 0 / 0 (0.0%)
 ```
 
-For an interactive view of job status, use `mqtop`. Press `r` to refresh the
-display. This command replaces the old `mqstat --watch` option.
+For an interactive view of job status, use `mqtop`. Navigate with the arrow
+keys or `j`/`k`, press `l` or `o` to view a job's stdout log, `e` for stderr,
+and `r` to refresh the display. This command replaces the old
+`mqstat --watch` option.
 
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:
 ```

--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ sternesp CPUs queued: 0
 Non-microbiome group jobs / CPU: 0 / 0 (0.0%)
 ```
 
+For an interactive, continuously updating view of job status, use `mqtop`.
+This command replaces the old `mqstat --watch` option.
+
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:
 ```
 List of jobs in queue:

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ sternesp CPUs queued: 0
 Non-microbiome group jobs / CPU: 0 / 0 (0.0%)
 ```
 
-For an interactive, continuously updating view of job status, use `mqtop`.
-This command replaces the old `mqstat --watch` option.
+For an interactive view of job status, use `mqtop`. Press `r` to refresh the
+display. This command replaces the old `mqstat --watch` option.
 
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:
 ```

--- a/README.md
+++ b/README.md
@@ -141,9 +141,10 @@ Non-microbiome group jobs / CPU: 0 / 0 (0.0%)
 
 For an interactive view of job status, use `mqtop`. Navigate with the arrow
 keys or `j`/`k`, or select rows with the mouse. Press `/` to search by job name
-or ID, `l` or `o` to view a job's stdout log, `e` for stderr, and `r` to refresh
-the display. A help footer summarises these keys. This command replaces the old
-`mqstat --watch` option.
+or ID. `l` or `o` shows a job's stdout log (using `ssh-to-job` for running
+jobs), `e` shows stderr, `f` runs `qstat -xf` for full details, `s` opens an
+interactive shell on a running job, and `r` refreshes the display. A help footer
+summarises these keys. This command replaces the old `mqstat --watch` option.
 
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:
 ```

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -885,18 +885,12 @@ def watch_jobs(get_jobs, interval=2):
 def main():
     parser = argparse.ArgumentParser(description="Cluster Usage Monitor")
     parser.add_argument("--list", action="store_true", help="Summarise qstat -f output")
-    parser.add_argument("--watch", action="store_true", help="Continuously watch job list")
     parser.add_argument("--qstat-file", help="Use qstat -f output from file")
     args = parser.parse_args()
 
     if args.list:
         jobs = parse_qstat(path=args.qstat_file)
         list_jobs(jobs)
-        return
-    if args.watch:
-        def get_jobs(include_history=False):
-            return parse_qstat(path=args.qstat_file, include_history=include_history)
-        watch_jobs(get_jobs)
         return
 
     # Get node data

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -625,7 +625,7 @@ def job_table(jobs, finished=False):
         ncpus_used = job.get('ncpus_used', job.get('ncpus', 0))
         if cpupercent is not None and ncpus_used:
             if cpupercent < ncpus_used * 10:
-                note = '❗ over-resourced? <10% of CPU used'
+                note = '❗ <10% of CPU used'
 
         waited = ''
         qtime = job.get('qtime')

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -309,7 +309,8 @@ def main() -> None:
         curses.mousemask(curses.BUTTON1_CLICKED)
 
         finished = {}
-        selected = 1
+        selected = 1  # absolute selected row index (1..)
+        offset = 0  # topmost job line displayed (0-based)
         lines, job_rows = [], []
         refresh = True
 
@@ -325,13 +326,21 @@ def main() -> None:
                     pass
                 else:
                     if 1 <= my < min(len(lines), maxy - 1):
-                        selected = my
+                        selected = min(offset + my, len(lines) - 1)
             elif key in (curses.KEY_DOWN, ord("j")):
                 if lines:
-                    selected = min(selected + 1, len(lines) - 1, maxy - 2)
+                    selected = min(selected + 1, len(lines) - 1)
             elif key in (curses.KEY_UP, ord("k")):
                 if lines:
                     selected = max(1, selected - 1)
+            elif key == curses.KEY_NPAGE:
+                if lines:
+                    page = maxy - 2
+                    selected = min(len(lines) - 1, selected + page)
+            elif key == curses.KEY_PPAGE:
+                if lines:
+                    page = maxy - 2
+                    selected = max(1, selected - page)
             elif key in (ord("l"), ord("o"), ord("e")):
                 if 0 < selected <= len(job_rows):
                     job = job_rows[selected - 1]
@@ -423,12 +432,23 @@ def main() -> None:
                 refresh = False
 
             stdscr.erase()
+            page = maxy - 2
             if lines:
-                selected = max(1, min(selected, len(lines) - 1, maxy - 2))
+                max_sel = len(lines) - 1
+                selected = min(max(1, selected), max_sel)
+                offset = max(0, min(offset, max_sel - page))
+                if selected < offset + 1:
+                    offset = selected - 1
+                elif selected > offset + page:
+                    offset = selected - page
                 draw_line(stdscr, 0, lines[0], maxx, highlight=True)
-                for i, line in enumerate(lines[1: maxy - 1], start=1):
-                    draw_line(stdscr, i, line, maxx, highlight=(i == selected))
-            help_text = "q quit  / search  l/o stdout  e stderr  f full  s ssh  r refresh"
+                visible = lines[1 + offset : 1 + offset + page]
+                for i, line in enumerate(visible, start=1):
+                    draw_line(stdscr, i, line, maxx, highlight=(offset + i == selected))
+            else:
+                offset = 0
+                selected = 1
+            help_text = "q quit  / search  o stdout  e stderr  f full  s ssh  r refresh"
             addstr_safe(stdscr, maxy - 1, 0, help_text, maxx)
             stdscr.refresh()
             time.sleep(0.1)

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -33,6 +33,8 @@ mqsub = _load_script("mqsub")
 
 
 ansi_re = re.compile(r"\x1b\[(\d+)m(.*?)\x1b\[0m")
+# basic ANSI colour escapes used for row colouring
+ORANGE = "\033[33m"
 
 
 def strip_ansi(text: str) -> str:
@@ -89,7 +91,8 @@ def draw_line(stdscr, y, line, maxx, highlight=False):
     for match in ansi_re.finditer(line):
         x += addstr_safe(stdscr, y, x, line[last:match.start()], maxx, attr)
         colour = match.group(1)
-        colour_pair = curses.color_pair(1 if colour == "92" else 2)
+        pair = {"92": 1, "91": 2, "93": 3, "33": 4}.get(colour, 0)
+        colour_pair = curses.color_pair(pair)
         x += addstr_safe(stdscr, y, x, match.group(2), maxx, colour_pair | attr)
         last = match.end()
         if x >= maxx - 1:
@@ -187,16 +190,16 @@ def format_jobs(jobs, now=None):
         )
 
         row_color = ""
-        if state not in ("C", "F"):
-            row_color = mqstat.Colors.GREEN
-        else:
-            end_time = job.get("obittime") or job.get("mtime")
-            if end_time and now - end_time < 600:
-                row_color = (
-                    mqstat.Colors.YELLOW
-                    if job.get("exit_status", 0) == 0
-                    else mqstat.Colors.RED
-                )
+        if state == "Q":
+            row_color = mqstat.Colors.YELLOW
+        elif state in ("C", "F"):
+            row_color = (
+                mqstat.Colors.GREEN
+                if job.get("exit_status", 0) == 0
+                else mqstat.Colors.RED
+            )
+        elif state != "R":
+            row_color = ORANGE
 
         rows.append(
             {
@@ -296,6 +299,11 @@ def main() -> None:
         curses.use_default_colors()
         curses.init_pair(1, curses.COLOR_GREEN, -1)
         curses.init_pair(2, curses.COLOR_RED, -1)
+        curses.init_pair(3, curses.COLOR_YELLOW, -1)
+        try:
+            curses.init_pair(4, 208, -1)  # orange if terminal supports it
+        except curses.error:
+            curses.init_pair(4, curses.COLOR_YELLOW, -1)
         stdscr.nodelay(True)
 
         finished = {}
@@ -313,17 +321,25 @@ def main() -> None:
             elif key in (curses.KEY_UP, ord("k")):
                 if lines:
                     selected = max(1, selected - 1)
-            elif key in (ord("l"), ord("o")):
+            elif key in (ord("l"), ord("o"), ord("e")):
                 if 0 < selected <= len(job_rows):
                     job = job_rows[selected - 1]
                     if job.get("state") in ("C", "F"):
                         try:
-                            stdout_path, _ = mqsub.PbsJobInfo.stdout_and_stderr_paths(job["id"])
+                            stdout_path, stderr_path = mqsub.PbsJobInfo.stdout_and_stderr_paths(job["id"])
                         except Exception:
-                            stdout_path = None
-                        if stdout_path and os.path.exists(stdout_path):
+                            stdout_path = stderr_path = None
+                        if key == ord("e"):
+                            path = stderr_path
+                            suffix = "ER"
+                        else:
+                            path = stdout_path
+                            suffix = "OU"
+                        if path and os.path.isdir(path):
+                            path = os.path.join(path, f"{job['id']}.{suffix}")
+                        if path and os.path.exists(path):
                             curses.endwin()
-                            subprocess.call(["less", stdout_path])
+                            subprocess.call(["less", path])
                             stdscr.clear()
                             curses.curs_set(0)
             elif key == ord("r"):
@@ -353,8 +369,10 @@ def main() -> None:
 
             maxy, maxx = stdscr.getmaxyx()
             stdscr.erase()
-            for i, line in enumerate(lines[: maxy]):
-                draw_line(stdscr, i, line, maxx, highlight=(i == selected))
+            if lines:
+                draw_line(stdscr, 0, lines[0], maxx, highlight=True)
+                for i, line in enumerate(lines[1: maxy], start=1):
+                    draw_line(stdscr, i, line, maxx, highlight=(i == selected))
             stdscr.refresh()
             time.sleep(0.1)
 

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Interactive job viewer similar to ``htop``.
+
+This tool combines running and recently finished jobs into a single table
+and allows selecting rows to inspect job logs.
+"""
+
+import argparse
+import importlib.util
+import os
+import re
+import subprocess
+import time
+import unicodedata
+from importlib.machinery import SourceFileLoader
+
+import curses
+
+
+def _load_script(name):
+    """Load a script from ``bin`` as a module."""
+
+    path = os.path.join(os.path.dirname(__file__), name)
+    loader = SourceFileLoader(f"{name}_module", path)
+    spec = importlib.util.spec_from_loader(f"{name}_module", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+
+mqstat = _load_script("mqstat")
+mqsub = _load_script("mqsub")
+
+
+ansi_re = re.compile(r"\x1b\[(\d+)m(.*?)\x1b\[0m")
+
+
+def _width(ch):
+    if unicodedata.combining(ch):
+        return 0
+    return 2 if unicodedata.east_asian_width(ch) in ("F", "W") else 1
+
+
+def addstr_safe(stdscr, y, x, text, maxx, attr=0):
+    width = 0
+    out = []
+    for ch in text:
+        w = _width(ch)
+        if x + width + w > maxx - 1:
+            break
+        out.append(ch)
+        width += w
+    if out:
+        try:
+            stdscr.addstr(y, x, "".join(out), attr)
+        except curses.error:
+            pass
+    return width
+
+
+def draw_line(stdscr, y, line, maxx, highlight=False):
+    """Draw a line that may contain ANSI colour escape codes."""
+
+    x = 0
+    last = 0
+    attr = curses.A_REVERSE if highlight else 0
+    for match in ansi_re.finditer(line):
+        x += addstr_safe(stdscr, y, x, line[last:match.start()], maxx, attr)
+        colour = match.group(1)
+        colour_pair = curses.color_pair(1 if colour == "92" else 2)
+        x += addstr_safe(stdscr, y, x, match.group(2), maxx, colour_pair | attr)
+        last = match.end()
+        if x >= maxx - 1:
+            break
+    if x < maxx - 1 and last < len(line):
+        addstr_safe(stdscr, y, x, line[last:], maxx, attr)
+
+
+def format_jobs(jobs):
+    """Return formatted job table lines and corresponding job objects."""
+
+    rows = []
+    headers = [
+        "job_id",
+        "name",
+        "time used",
+        "progress",
+        "walltime",
+        "waited",
+        "CPU",
+        "cpu%",
+        "RAM(G)",
+        "ram%",
+        "state",
+        "queue",
+        "note",
+    ]
+
+    for job in jobs:
+        queue = job.get("queue", "").replace("_batch_exec", "")
+        job_id = job.get("id", "")
+        name = job.get("name", "")
+        used_s = job.get("walltime_used", 0)
+        total_s = job.get("walltime_total", job.get("walltime", 0))
+        used = mqstat.format_hm(used_s)
+        total = mqstat.format_hm(total_s)
+        bar = mqstat.progress_bar(used_s, total_s)
+        waited = ""
+        qtime = job.get("qtime")
+        start_time = job.get("start_time")
+        if qtime and start_time and start_time > qtime:
+            waited = mqstat.format_hm(start_time - qtime)
+
+        cpu = job.get("ncpus", 0)
+        cpupercent = job.get("cpupercent")
+        ncpus_used = job.get("ncpus_used", cpu)
+        cpu_util = 0
+        if job.get("state") in ("C", "F"):
+            cput_used = job.get("cput_used", 0)
+            if used_s and cpu:
+                cpu_util = cput_used / (used_s * cpu) * 100
+        elif cpupercent is not None and ncpus_used:
+            cpu_util = cpupercent / ncpus_used
+        cpu_util_str = f"{int(cpu_util)}%" if cpu_util else ""
+        cpu_low = cpu_util and cpu_util < 10
+
+        ram = int(job.get("mem_request_gb", 0))
+        vmem_kb = job.get("vmem_used_kb") or job.get("mem_usage", 0)
+        ram_util = (vmem_kb / (ram * 1024 * 1024) * 100) if ram else 0
+        ram_util_str = f"{int(ram_util)}%" if ram_util else ""
+        ram_low = ram_util and ram_util < 10
+
+        state = job.get("state", "")
+        note = ""
+        if state not in ("C", "F"):
+            if cpupercent is not None and ncpus_used and cpupercent < ncpus_used * 10:
+                note = "❗ over-resourced? <10% of CPU used"
+        else:
+            if used_s < 60:
+                note = "short"
+            elif cpu_low and ram_low:
+                note = "<10% CPU, <10% RAM"
+            elif cpu_low:
+                note = "<10% CPU"
+            elif ram_low:
+                note = "<10% RAM"
+            if job.get("exit_status", 0) != 0:
+                note = "!" + note
+
+        rows.append(
+            {
+                "job_id": job_id,
+                "name": name,
+                "used": used,
+                "bar": bar,
+                "wall": total,
+                "waited": waited,
+                "cpu": str(cpu),
+                "cpu_util": mqstat.Colors.RED + cpu_util_str + mqstat.Colors.ENDC if cpu_low else cpu_util_str,
+                "ram": str(ram),
+                "ram_util": mqstat.Colors.RED + ram_util_str + mqstat.Colors.ENDC if ram_low else ram_util_str,
+                "state": state,
+                "queue": queue,
+                "note": note,
+                "raw": job,
+            }
+        )
+
+    if not rows:
+        return ["  ".join(headers)], []
+
+    id_w = max(len(headers[0]), max(len(r["job_id"]) for r in rows))
+    name_w = max(len(headers[1]), max(len(r["name"]) for r in rows))
+    time_w = len(headers[2])
+    wall_w = max(len(headers[4]), max(len(r["wall"]) for r in rows))
+    wait_w = max(len(headers[5]), max(len(r["waited"]) for r in rows))
+    cpu_w = max(len(headers[6]), max(len(r["cpu"]) for r in rows))
+    cpuu_w = max(len(headers[7]), max(len(r["cpu_util"]) for r in rows))
+    ram_w = max(len(headers[8]), max(len(r["ram"]) for r in rows))
+    ramu_w = max(len(headers[9]), max(len(r["ram_util"]) for r in rows))
+    state_w = max(len(headers[10]), max(len(r["state"]) for r in rows))
+    queue_w = max(len(headers[11]), max(len(r["queue"]) for r in rows))
+    note_w = max(len(headers[12]), max(len(r["note"]) for r in rows))
+
+    header_parts = [
+        headers[0].ljust(id_w),
+        headers[1].ljust(name_w),
+        headers[2].ljust(time_w),
+        headers[3].ljust(20),
+        headers[4].ljust(wall_w),
+        headers[5].ljust(wait_w),
+        headers[6].rjust(cpu_w),
+        headers[7].rjust(cpuu_w),
+        headers[8].rjust(ram_w),
+        headers[9].rjust(ramu_w),
+        headers[10].ljust(state_w),
+        headers[11].ljust(queue_w),
+        headers[12].ljust(note_w),
+    ]
+    lines = ["  ".join(header_parts)]
+
+    for r in rows:
+        parts = [
+            r["job_id"].ljust(id_w),
+            r["name"].ljust(name_w),
+            r["used"].ljust(time_w),
+            r["bar"],
+            r["wall"].ljust(wall_w),
+            r["waited"].ljust(wait_w),
+            r["cpu"].rjust(cpu_w),
+            r["cpu_util"].rjust(cpuu_w),
+            r["ram"].rjust(ram_w),
+            r["ram_util"].rjust(ramu_w),
+            r["state"].ljust(state_w),
+            r["queue"].ljust(queue_w),
+            r["note"].ljust(note_w),
+        ]
+        lines.append("  ".join(parts))
+
+    jobs_out = [r["raw"] for r in rows]
+    return lines, jobs_out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Continuously watch job list")
+    parser.add_argument("--qstat-file", help="Use qstat -f output from file", default=None)
+    parser.add_argument("--interval", type=float, default=2, help="Refresh interval in seconds")
+    args = parser.parse_args()
+
+    def get_jobs(include_history: bool = False):
+        return mqstat.parse_qstat(path=args.qstat_file, include_history=include_history)
+
+    def _draw(stdscr):
+        curses.curs_set(0)
+        curses.start_color()
+        curses.use_default_colors()
+        curses.init_pair(1, curses.COLOR_GREEN, -1)
+        curses.init_pair(2, curses.COLOR_RED, -1)
+        stdscr.nodelay(True)
+
+        finished = {}
+        selected = 1
+        lines, job_rows = [], []
+
+        while True:
+            key = stdscr.getch()
+            if key == ord("q"):
+                break
+            elif key in (curses.KEY_DOWN, ord("j")):
+                if lines:
+                    selected = min(selected + 1, len(lines) - 1)
+            elif key in (curses.KEY_UP, ord("k")):
+                if lines:
+                    selected = max(1, selected - 1)
+            elif key in (ord("l"), ord("o")):
+                if 0 < selected <= len(job_rows):
+                    job = job_rows[selected - 1]
+                    if job.get("state") in ("C", "F"):
+                        try:
+                            stdout_path, _ = mqsub.PbsJobInfo.stdout_and_stderr_paths(job["id"])
+                        except Exception:
+                            stdout_path = None
+                        if stdout_path and os.path.exists(stdout_path):
+                            curses.endwin()
+                            subprocess.call(["less", stdout_path])
+                            stdscr.clear()
+                            curses.curs_set(0)
+
+            jobs = get_jobs(include_history=True)
+            now = time.time()
+            running = []
+            for job in jobs:
+                if job.get("state") in ("C", "F"):
+                    ft = job.get("obittime") or job.get("mtime", now)
+                    if now - ft <= 24 * 3600:
+                        finished[job["id"]] = job
+                else:
+                    running.append(job)
+            for jid, job in list(finished.items()):
+                ft = job.get("obittime") or job.get("mtime", now)
+                if now - ft > 24 * 3600:
+                    finished.pop(jid, None)
+
+            all_jobs = running + list(finished.values())
+            lines, job_rows = format_jobs(all_jobs)
+
+            maxy, maxx = stdscr.getmaxyx()
+            stdscr.erase()
+            for i, line in enumerate(lines[: maxy]):
+                draw_line(stdscr, i, line, maxx, highlight=(i == selected))
+            stdscr.refresh()
+            time.sleep(args.interval)
+
+    curses.wrapper(_draw)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -305,6 +305,8 @@ def main() -> None:
         except curses.error:
             curses.init_pair(4, curses.COLOR_YELLOW, -1)
         stdscr.nodelay(True)
+        stdscr.keypad(True)
+        curses.mousemask(curses.BUTTON1_CLICKED)
 
         finished = {}
         selected = 1
@@ -312,12 +314,21 @@ def main() -> None:
         refresh = True
 
         while True:
+            maxy, maxx = stdscr.getmaxyx()
             key = stdscr.getch()
             if key == ord("q"):
                 break
+            elif key == curses.KEY_MOUSE:
+                try:
+                    _, _, my, _, _ = curses.getmouse()
+                except curses.error:
+                    pass
+                else:
+                    if 1 <= my < min(len(lines), maxy - 1):
+                        selected = my
             elif key in (curses.KEY_DOWN, ord("j")):
                 if lines:
-                    selected = min(selected + 1, len(lines) - 1)
+                    selected = min(selected + 1, len(lines) - 1, maxy - 2)
             elif key in (curses.KEY_UP, ord("k")):
                 if lines:
                     selected = max(1, selected - 1)
@@ -342,6 +353,24 @@ def main() -> None:
                             subprocess.call(["less", path])
                             stdscr.clear()
                             curses.curs_set(0)
+            elif key == ord("/"):
+                curses.echo()
+                stdscr.nodelay(False)
+                stdscr.move(maxy - 1, 0)
+                stdscr.clrtoeol()
+                stdscr.addstr(maxy - 1, 0, "/")
+                try:
+                    query = stdscr.getstr(maxy - 1, 1).decode()
+                except Exception:
+                    query = ""
+                stdscr.nodelay(True)
+                curses.noecho()
+                if query:
+                    ql = query.lower()
+                    for idx, job in enumerate(job_rows, start=1):
+                        if ql in job.get("name", "").lower() or ql in str(job.get("id", "")).lower():
+                            selected = idx
+                            break
             elif key == ord("r"):
                 refresh = True
 
@@ -367,12 +396,14 @@ def main() -> None:
                 lines, job_rows = format_jobs(all_jobs, now=now)
                 refresh = False
 
-            maxy, maxx = stdscr.getmaxyx()
             stdscr.erase()
             if lines:
+                selected = max(1, min(selected, len(lines) - 1, maxy - 2))
                 draw_line(stdscr, 0, lines[0], maxx, highlight=True)
-                for i, line in enumerate(lines[1: maxy], start=1):
+                for i, line in enumerate(lines[1: maxy - 1], start=1):
                     draw_line(stdscr, i, line, maxx, highlight=(i == selected))
+            help_text = "q quit  / search  o stdout  e stderr  r refresh"
+            addstr_safe(stdscr, maxy - 1, 0, help_text, maxx)
             stdscr.refresh()
             time.sleep(0.1)
 

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -165,7 +165,7 @@ def format_jobs(jobs, now=None):
         note = ""
         if state not in ("C", "F"):
             if cpupercent is not None and ncpus_used and cpupercent < ncpus_used * 10:
-                note = "❗ over-resourced? <10% of CPU used"
+                note = "❗ <10% of CPU used"
         else:
             if used_s < 60:
                 note = "short"

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -35,6 +35,28 @@ mqsub = _load_script("mqsub")
 ansi_re = re.compile(r"\x1b\[(\d+)m(.*?)\x1b\[0m")
 
 
+def strip_ansi(text: str) -> str:
+    """Return *text* with ANSI colour escapes removed."""
+
+    return ansi_re.sub(r"\2", text)
+
+
+def visible_len(text: str) -> int:
+    """Length of *text* ignoring ANSI colour escapes."""
+
+    return len(strip_ansi(text))
+
+
+def ljust_ansi(text: str, width: int) -> str:
+    pad = max(width - visible_len(text), 0)
+    return text + " " * pad
+
+
+def rjust_ansi(text: str, width: int) -> str:
+    pad = max(width - visible_len(text), 0)
+    return " " * pad + text
+
+
 def _width(ch):
     if unicodedata.combining(ch):
         return 0
@@ -76,8 +98,11 @@ def draw_line(stdscr, y, line, maxx, highlight=False):
         addstr_safe(stdscr, y, x, line[last:], maxx, attr)
 
 
-def format_jobs(jobs):
+def format_jobs(jobs, now=None):
     """Return formatted job table lines and corresponding job objects."""
+
+    if now is None:
+        now = time.time()
 
     rows = []
     headers = [
@@ -97,6 +122,8 @@ def format_jobs(jobs):
     ]
 
     for job in jobs:
+        if job.get("queue") == "cpu_inter_exec":
+            continue
         queue = job.get("queue", "").replace("_batch_exec", "")
         job_id = job.get("id", "")
         name = job.get("name", "")
@@ -123,6 +150,7 @@ def format_jobs(jobs):
             cpu_util = cpupercent / ncpus_used
         cpu_util_str = f"{int(cpu_util)}%" if cpu_util else ""
         cpu_low = cpu_util and cpu_util < 10
+        short_run = used_s <= 120
 
         ram = int(job.get("mem_request_gb", 0))
         vmem_kb = job.get("vmem_used_kb") or job.get("mem_usage", 0)
@@ -147,6 +175,29 @@ def format_jobs(jobs):
             if job.get("exit_status", 0) != 0:
                 note = "!" + note
 
+        cpu_field = (
+            mqstat.Colors.RED + cpu_util_str + mqstat.Colors.ENDC
+            if cpu_low and not short_run
+            else cpu_util_str
+        )
+        ram_field = (
+            mqstat.Colors.RED + ram_util_str + mqstat.Colors.ENDC
+            if ram_low and not short_run
+            else ram_util_str
+        )
+
+        row_color = ""
+        if state not in ("C", "F"):
+            row_color = mqstat.Colors.GREEN
+        else:
+            end_time = job.get("obittime") or job.get("mtime")
+            if end_time and now - end_time < 600:
+                row_color = (
+                    mqstat.Colors.YELLOW
+                    if job.get("exit_status", 0) == 0
+                    else mqstat.Colors.RED
+                )
+
         rows.append(
             {
                 "job_id": job_id,
@@ -156,31 +207,32 @@ def format_jobs(jobs):
                 "wall": total,
                 "waited": waited,
                 "cpu": str(cpu),
-                "cpu_util": mqstat.Colors.RED + cpu_util_str + mqstat.Colors.ENDC if cpu_low else cpu_util_str,
+                "cpu_util": cpu_field,
                 "ram": str(ram),
-                "ram_util": mqstat.Colors.RED + ram_util_str + mqstat.Colors.ENDC if ram_low else ram_util_str,
+                "ram_util": ram_field,
                 "state": state,
                 "queue": queue,
                 "note": note,
                 "raw": job,
+                "row_color": row_color,
             }
         )
 
     if not rows:
         return ["  ".join(headers)], []
 
-    id_w = max(len(headers[0]), max(len(r["job_id"]) for r in rows))
-    name_w = max(len(headers[1]), max(len(r["name"]) for r in rows))
+    id_w = max(len(headers[0]), max(visible_len(r["job_id"]) for r in rows))
+    name_w = max(len(headers[1]), max(visible_len(r["name"]) for r in rows))
     time_w = len(headers[2])
-    wall_w = max(len(headers[4]), max(len(r["wall"]) for r in rows))
-    wait_w = max(len(headers[5]), max(len(r["waited"]) for r in rows))
-    cpu_w = max(len(headers[6]), max(len(r["cpu"]) for r in rows))
-    cpuu_w = max(len(headers[7]), max(len(r["cpu_util"]) for r in rows))
-    ram_w = max(len(headers[8]), max(len(r["ram"]) for r in rows))
-    ramu_w = max(len(headers[9]), max(len(r["ram_util"]) for r in rows))
-    state_w = max(len(headers[10]), max(len(r["state"]) for r in rows))
-    queue_w = max(len(headers[11]), max(len(r["queue"]) for r in rows))
-    note_w = max(len(headers[12]), max(len(r["note"]) for r in rows))
+    wall_w = max(len(headers[4]), max(visible_len(r["wall"]) for r in rows))
+    wait_w = max(len(headers[5]), max(visible_len(r["waited"]) for r in rows))
+    cpu_w = max(len(headers[6]), max(visible_len(r["cpu"]) for r in rows))
+    cpuu_w = max(len(headers[7]), max(visible_len(r["cpu_util"]) for r in rows))
+    ram_w = max(len(headers[8]), max(visible_len(r["ram"]) for r in rows))
+    ramu_w = max(len(headers[9]), max(visible_len(r["ram_util"]) for r in rows))
+    state_w = max(len(headers[10]), max(visible_len(r["state"]) for r in rows))
+    queue_w = max(len(headers[11]), max(visible_len(r["queue"]) for r in rows))
+    note_w = max(len(headers[12]), max(visible_len(r["note"]) for r in rows))
 
     header_parts = [
         headers[0].ljust(id_w),
@@ -201,30 +253,38 @@ def format_jobs(jobs):
 
     for r in rows:
         parts = [
-            r["job_id"].ljust(id_w),
-            r["name"].ljust(name_w),
-            r["used"].ljust(time_w),
+            ljust_ansi(r["job_id"], id_w),
+            ljust_ansi(r["name"], name_w),
+            ljust_ansi(r["used"], time_w),
             r["bar"],
-            r["wall"].ljust(wall_w),
-            r["waited"].ljust(wait_w),
-            r["cpu"].rjust(cpu_w),
-            r["cpu_util"].rjust(cpuu_w),
-            r["ram"].rjust(ram_w),
-            r["ram_util"].rjust(ramu_w),
-            r["state"].ljust(state_w),
-            r["queue"].ljust(queue_w),
-            r["note"].ljust(note_w),
+            ljust_ansi(r["wall"], wall_w),
+            ljust_ansi(r["waited"], wait_w),
+            rjust_ansi(r["cpu"], cpu_w),
+            rjust_ansi(r["cpu_util"], cpuu_w),
+            rjust_ansi(r["ram"], ram_w),
+            rjust_ansi(r["ram_util"], ramu_w),
+            ljust_ansi(r["state"], state_w),
+            ljust_ansi(r["queue"], queue_w),
+            ljust_ansi(r["note"], note_w),
         ]
-        lines.append("  ".join(parts))
+        coloured_parts = []
+        row_colour = r.get("row_color", "")
+        for idx, part in enumerate(parts):
+            if idx == 3:  # progress column
+                coloured_parts.append(part)
+            elif row_colour and not ansi_re.search(part):
+                coloured_parts.append(row_colour + part + mqstat.Colors.ENDC)
+            else:
+                coloured_parts.append(part)
+        lines.append("  ".join(coloured_parts))
 
     jobs_out = [r["raw"] for r in rows]
     return lines, jobs_out
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Continuously watch job list")
+    parser = argparse.ArgumentParser(description="Interactive job viewer")
     parser.add_argument("--qstat-file", help="Use qstat -f output from file", default=None)
-    parser.add_argument("--interval", type=float, default=2, help="Refresh interval in seconds")
     args = parser.parse_args()
 
     def get_jobs(include_history: bool = False):
@@ -241,6 +301,7 @@ def main() -> None:
         finished = {}
         selected = 1
         lines, job_rows = [], []
+        refresh = True
 
         while True:
             key = stdscr.getch()
@@ -265,31 +326,37 @@ def main() -> None:
                             subprocess.call(["less", stdout_path])
                             stdscr.clear()
                             curses.curs_set(0)
+            elif key == ord("r"):
+                refresh = True
 
-            jobs = get_jobs(include_history=True)
-            now = time.time()
-            running = []
-            for job in jobs:
-                if job.get("state") in ("C", "F"):
+            if refresh:
+                jobs = get_jobs(include_history=True)
+                now = time.time()
+                running = []
+                for job in jobs:
+                    if job.get("queue") == "cpu_inter_exec":
+                        continue
+                    if job.get("state") in ("C", "F"):
+                        ft = job.get("obittime") or job.get("mtime", now)
+                        if now - ft <= 24 * 3600:
+                            finished[job["id"]] = job
+                    else:
+                        running.append(job)
+                for jid, job in list(finished.items()):
                     ft = job.get("obittime") or job.get("mtime", now)
-                    if now - ft <= 24 * 3600:
-                        finished[job["id"]] = job
-                else:
-                    running.append(job)
-            for jid, job in list(finished.items()):
-                ft = job.get("obittime") or job.get("mtime", now)
-                if now - ft > 24 * 3600:
-                    finished.pop(jid, None)
+                    if now - ft > 24 * 3600 or job.get("queue") == "cpu_inter_exec":
+                        finished.pop(jid, None)
 
-            all_jobs = running + list(finished.values())
-            lines, job_rows = format_jobs(all_jobs)
+                all_jobs = running + list(finished.values())
+                lines, job_rows = format_jobs(all_jobs, now=now)
+                refresh = False
 
             maxy, maxx = stdscr.getmaxyx()
             stdscr.erase()
             for i, line in enumerate(lines[: maxy]):
                 draw_line(stdscr, i, line, maxx, highlight=(i == selected))
             stdscr.refresh()
-            time.sleep(args.interval)
+            time.sleep(0.1)
 
     curses.wrapper(_draw)
 

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -335,7 +335,8 @@ def main() -> None:
             elif key in (ord("l"), ord("o"), ord("e")):
                 if 0 < selected <= len(job_rows):
                     job = job_rows[selected - 1]
-                    if job.get("state") in ("C", "F"):
+                    state = job.get("state")
+                    if state in ("C", "F"):
                         try:
                             stdout_path, stderr_path = mqsub.PbsJobInfo.stdout_and_stderr_paths(job["id"])
                         except Exception:
@@ -353,6 +354,31 @@ def main() -> None:
                             subprocess.call(["less", path])
                             stdscr.clear()
                             curses.curs_set(0)
+                    elif state == "R":
+                        suffix = "ER" if key == ord("e") else "OU"
+                        cmd = (
+                            f"/pkg/hpc/scripts/ssh-to-job {job['id']} cat /var/spool/PBS/spool/{job['id']}.{suffix} | less"
+                        )
+                        curses.endwin()
+                        subprocess.call(cmd, shell=True)
+                        stdscr.clear()
+                        curses.curs_set(0)
+            elif key == ord("f"):
+                if 0 < selected <= len(job_rows):
+                    job = job_rows[selected - 1]
+                    cmd = f"qstat -xf {job['id']} | less"
+                    curses.endwin()
+                    subprocess.call(cmd, shell=True)
+                    stdscr.clear()
+                    curses.curs_set(0)
+            elif key == ord("s"):
+                if 0 < selected <= len(job_rows):
+                    job = job_rows[selected - 1]
+                    if job.get("state") == "R":
+                        curses.endwin()
+                        subprocess.call(["/pkg/hpc/scripts/ssh-to-job", str(job["id"])])
+                        stdscr.clear()
+                        curses.curs_set(0)
             elif key == ord("/"):
                 curses.echo()
                 stdscr.nodelay(False)
@@ -402,7 +428,7 @@ def main() -> None:
                 draw_line(stdscr, 0, lines[0], maxx, highlight=True)
                 for i, line in enumerate(lines[1: maxy - 1], start=1):
                     draw_line(stdscr, i, line, maxx, highlight=(i == selected))
-            help_text = "q quit  / search  o stdout  e stderr  r refresh"
+            help_text = "q quit  / search  l/o stdout  e stderr  f full  s ssh  r refresh"
             addstr_safe(stdscr, maxy - 1, 0, help_text, maxx)
             stdscr.refresh()
             time.sleep(0.1)

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -300,9 +300,12 @@ def main() -> None:
         curses.init_pair(1, curses.COLOR_GREEN, -1)
         curses.init_pair(2, curses.COLOR_RED, -1)
         curses.init_pair(3, curses.COLOR_YELLOW, -1)
-        try:
-            curses.init_pair(4, 208, -1)  # orange if terminal supports it
-        except curses.error:
+        if getattr(curses, "COLORS", 8) > 208:
+            try:
+                curses.init_pair(4, 208, -1)  # orange if terminal supports it
+            except (curses.error, ValueError):
+                curses.init_pair(4, curses.COLOR_YELLOW, -1)
+        else:
             curses.init_pair(4, curses.COLOR_YELLOW, -1)
         stdscr.nodelay(True)
         stdscr.keypad(True)

--- a/tests/test_mqstat.py
+++ b/tests/test_mqstat.py
@@ -69,7 +69,8 @@ def test_mqstat_list():
     assert rows[2][7] == "R"
     assert rows[2][8] == "batch"
     assert rows[2][9].startswith("❗")
-    assert "over-resourced" in rows[2][9]
+    assert "over-resourced" not in rows[2][9]
+    assert "<10% of CPU used" in rows[2][9]
     assert "💪" in lines[3]
     assert "\x1b[92m" in lines[3]
 

--- a/tests/test_mqtop.py
+++ b/tests/test_mqtop.py
@@ -41,3 +41,28 @@ def test_format_jobs_has_superset_columns():
         assert col in header
     assert len(rows) == 2
 
+
+def test_short_runtime_not_coloured_red():
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "bin" / "mqtop"
+    mod = runpy.run_path(str(script))
+
+    jobs = [
+        {
+            "id": "1",
+            "name": "short",
+            "walltime_used": 100,
+            "walltime_total": 200,
+            "ncpus": 1,
+            "mem_request_gb": 1,
+            "state": "R",
+            "queue": "cpu",
+            "cpupercent": 5,
+            "ncpus_used": 1,
+            "mem_usage": 512 * 1024,
+        }
+    ]
+
+    lines, _ = mod["format_jobs"](jobs)
+    assert "\033[91m" not in lines[1]
+

--- a/tests/test_mqtop.py
+++ b/tests/test_mqtop.py
@@ -1,0 +1,43 @@
+import runpy
+from pathlib import Path
+
+
+def test_format_jobs_has_superset_columns():
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "bin" / "mqtop"
+    mod = runpy.run_path(str(script))
+
+    jobs = [
+        {
+            "id": "1",
+            "name": "run",
+            "walltime_used": 10,
+            "walltime_total": 20,
+            "ncpus": 2,
+            "mem_request_gb": 4,
+            "state": "R",
+            "queue": "cpu",
+            "cpupercent": 50,
+            "ncpus_used": 2,
+            "mem_usage": 2 * 1024 * 1024,
+        },
+        {
+            "id": "2",
+            "name": "done",
+            "walltime_used": 10,
+            "walltime_total": 20,
+            "ncpus": 1,
+            "mem_request_gb": 2,
+            "state": "C",
+            "queue": "cpu",
+            "cput_used": 10,
+            "vmem_used_kb": 1024 * 1024,
+        },
+    ]
+
+    lines, rows = mod["format_jobs"](jobs)
+    header = lines[0]
+    for col in ["waited", "cpu%", "ram%", "state"]:
+        assert col in header
+    assert len(rows) == 2
+


### PR DESCRIPTION
## Summary
- replace legacy watch UI with single-table `mqtop` showing running and finished jobs
- allow row selection with navigation keys and open stdout logs with `l`/`o`
- add unit test verifying superset column headers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa4e52782c832aa13c0cdeb3f2f310