### PR TITLE
Add optional job limit to mqtop

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ keys or `j`/`k`, or select rows with the mouse. Use `--max-jobs` to limit the
 number of jobs retrieved (default 500). Press `/` to search by job name or ID.
 `l` or `o` shows a job's stdout log (using `ssh-to-job` for running jobs), `e`
 shows stderr, `f` runs `qstat -xf` for full details, `s` opens an interactive
-shell on a running job, and `r` refreshes the display. A help footer summarises
-these keys. This command replaces the old `mqstat --watch` option.
+shell on a running job, `r` refreshes the display, and `u` hides or shows queued
+jobs. A help footer summarises these keys. This command replaces the old
+`mqstat --watch` option.
 
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:
 ```

--- a/README.md
+++ b/README.md
@@ -140,11 +140,12 @@ Non-microbiome group jobs / CPU: 0 / 0 (0.0%)
 ```
 
 For an interactive view of job status, use `mqtop`. Navigate with the arrow
-keys or `j`/`k`, or select rows with the mouse. Press `/` to search by job name
-or ID. `l` or `o` shows a job's stdout log (using `ssh-to-job` for running
-jobs), `e` shows stderr, `f` runs `qstat -xf` for full details, `s` opens an
-interactive shell on a running job, and `r` refreshes the display. A help footer
-summarises these keys. This command replaces the old `mqstat --watch` option.
+keys or `j`/`k`, or select rows with the mouse. Use `--max-jobs` to limit the
+number of jobs retrieved (default 500). Press `/` to search by job name or ID.
+`l` or `o` shows a job's stdout log (using `ssh-to-job` for running jobs), `e`
+shows stderr, `f` runs `qstat -xf` for full details, `s` opens an interactive
+shell on a running job, and `r` refreshes the display. A help footer summarises
+these keys. This command replaces the old `mqstat --watch` option.
 
 You can also view a detailed breakdown queued and running jobs on a per-user basis by typing `mqstat --list`. Example output:
 ```

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -16,6 +16,7 @@ import pwd
 import sys
 import grp
 import argparse
+import time
 from collections import defaultdict
 from datetime import datetime
 
@@ -604,6 +605,7 @@ def parse_qusers_output():
 def job_table(jobs, finished=False):
     """Return formatted job table lines."""
     rows = []
+    now = time.time()
     for job in jobs:
         queue = job.get('queue', '')
         if queue in ('cpu_inter_exec', 'gpu_inter_exec'):
@@ -631,10 +633,14 @@ def job_table(jobs, finished=False):
         waited = ''
         qtime = job.get('qtime')
         start_time = job.get('start_time')
-        if qtime and start_time and start_time > qtime:
-            waited = format_hm(start_time - qtime)
+        if qtime and start_time:
+            waited = format_hm(max(0, start_time - qtime))
 
         if finished:
+            age = ''
+            ft = job.get('obittime') or job.get('mtime')
+            if ft:
+                age = format_hm(max(0, int(now - ft)))
             cput_used = job.get('cput_used', 0)
             cpu_util = 0
             if used_s and cpu > 0:
@@ -666,6 +672,7 @@ def job_table(jobs, finished=False):
                 bar,
                 total,
                 waited,
+                age,
                 cpu,
                 cpu_icon,
                 cpu_util_str,
@@ -689,6 +696,7 @@ def job_table(jobs, finished=False):
             "progress",
             "walltime",
             "waited",
+            "age",
             "CPU",
             "util(%)",
             "RAM(G)",
@@ -709,12 +717,13 @@ def job_table(jobs, finished=False):
 
     if finished:
         wait_w = max(len(headers[5]), max(len(r[5]) for r in rows))
-        cpu_w = max(len(headers[6]), max(len(str(r[6])) for r in rows))
-        cpuu_w = max(len(headers[7]), max(len(r[8]) for r in rows))
-        ram_w = max(len(headers[8]), max(len(str(r[10])) for r in rows))
-        ramu_w = max(len(headers[9]), max(len(r[12]) for r in rows))
-        queue_w = max(len(headers[10]), max(len(r[14]) for r in rows))
-        note_w = max(len(headers[11]), max(len(r[15]) for r in rows))
+        age_w = max(len(headers[6]), max(len(r[6]) for r in rows))
+        cpu_w = max(len(headers[7]), max(len(str(r[7])) for r in rows))
+        cpuu_w = max(len(headers[8]), max(len(r[9]) for r in rows))
+        ram_w = max(len(headers[9]), max(len(str(r[11])) for r in rows))
+        ramu_w = max(len(headers[10]), max(len(r[13]) for r in rows))
+        queue_w = max(len(headers[11]), max(len(r[15]) for r in rows))
+        note_w = max(len(headers[12]), max(len(r[16]) for r in rows))
 
         def colour(val, low):
             return f"{Colors.RED}{val}{Colors.ENDC}" if low else val
@@ -726,12 +735,13 @@ def job_table(jobs, finished=False):
             headers[3].ljust(20),
             headers[4].ljust(wall_w),
             headers[5].ljust(wait_w),
-            headers[6].rjust(cpu_w) + ' ' * icon_w,
-            headers[7].rjust(cpuu_w),
-            headers[8].rjust(ram_w) + ' ' * icon_w,
-            headers[9].rjust(ramu_w),
-            headers[10].ljust(queue_w),
-            headers[11].ljust(note_w),
+            headers[6].ljust(age_w),
+            headers[7].rjust(cpu_w) + ' ' * icon_w,
+            headers[8].rjust(cpuu_w),
+            headers[9].rjust(ram_w) + ' ' * icon_w,
+            headers[10].rjust(ramu_w),
+            headers[11].ljust(queue_w),
+            headers[12].ljust(note_w),
         ]
         lines = ["  ".join(header_parts)]
         for r in rows:
@@ -742,16 +752,17 @@ def job_table(jobs, finished=False):
                 r[3],
                 r[4].ljust(wall_w),
                 r[5].ljust(wait_w),
-                str(r[6]).rjust(cpu_w) + r[7] + ' ' * (icon_w - (2 if r[7] else 0)),
-                colour(r[8].rjust(cpuu_w), r[9]),
-                str(r[10]).rjust(ram_w) + r[11] + ' ' * (icon_w - (2 if r[11] else 0)),
-                colour(r[12].rjust(ramu_w), r[13]),
-                r[14].ljust(queue_w),
-                r[15].ljust(note_w),
+                r[6].ljust(age_w),
+                str(r[7]).rjust(cpu_w) + r[8] + ' ' * (icon_w - (2 if r[8] else 0)),
+                colour(r[9].rjust(cpuu_w), r[10]),
+                str(r[11]).rjust(ram_w) + r[12] + ' ' * (icon_w - (2 if r[12] else 0)),
+                colour(r[13].rjust(ramu_w), r[14]),
+                r[15].ljust(queue_w),
+                r[16].ljust(note_w),
             ]
             lines.append("  ".join(parts))
         if parse_qstat.limit_hit:
-            warning = f"{Colors.BOLD}{Colors.RED}WARNING: job list truncated; running/queued jobs may be missing{Colors.ENDC}"
+            warning = f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more running/queued jobs{Colors.ENDC}"
             lines.insert(0, warning)
         return lines
     else:
@@ -789,7 +800,7 @@ def job_table(jobs, finished=False):
             ]
             lines.append("  ".join(parts))
         if parse_qstat.limit_hit:
-            warning = f"{Colors.BOLD}{Colors.RED}WARNING: job list truncated; running/queued jobs may be missing{Colors.ENDC}"
+            warning = f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more running/queued jobs{Colors.ENDC}"
             lines.insert(0, warning)
         return lines
 

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -626,7 +626,7 @@ def job_table(jobs, finished=False):
         note = ''
         cpupercent = job.get('cpupercent')
         ncpus_used = job.get('ncpus_used', job.get('ncpus', 0))
-        if cpupercent is not None and ncpus_used:
+        if cpupercent is not None and ncpus_used and used_s >= 120:
             if cpupercent < ncpus_used * 10:
                 note = '❗ <10% of CPU used'
 

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -111,7 +111,7 @@ def parse_pbsnodes_output():
 
     return nodes
 
-def parse_qstat(path=None, include_history=False):
+def parse_qstat(path=None, include_history=False, max_jobs=None):
     """Parse qstat output to get job information."""
     if path is None:
         path = os.environ.get("MQSTAT_QSTAT_F")
@@ -124,6 +124,12 @@ def parse_qstat(path=None, include_history=False):
         cmd = "qstat -f -t"
         if include_history:
             cmd = "qstat -xf -t"
+        if max_jobs:
+            # Limit the number of jobs returned to speed up queries on large clusters
+            cmd = (
+                f"qstat -{'x' if include_history else ''}f | "
+                f"awk '/Job Id:/{{if (count++=={max_jobs}) exit}} {{print}}'"
+            )
         output = run_command(cmd)
         if not output:
             return []

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -112,203 +112,198 @@ def parse_pbsnodes_output():
     return nodes
 
 def parse_qstat(path=None, include_history=False, max_jobs=None):
-    """Parse qstat output to get job information."""
+    """Parse qstat output and merge active and historical jobs."""
+
+    parse_qstat.limit_hit = False
+
+    def _parse(output):
+        jobs = []
+        current_job = None
+        for line in output.splitlines():
+            job_match = re.match(r'^Job Id: (.+)$', line)
+            if job_match:
+                if current_job:
+                    jobs.append(current_job)
+                current_job = {'id': job_match.group(1), 'user': None, 'ncpus': 0,
+                               'cpu_usage': 0, 'mem_usage': 0, 'gpu_usage': 0,
+                               'state': None}
+                continue
+            if not current_job:
+                continue
+
+            name_match = re.search(r'Job_Name = (.+)', line)
+            if name_match:
+                current_job['name'] = name_match.group(1)
+
+            queue_match = re.search(r'queue = (.+)', line)
+            if queue_match:
+                current_job['queue'] = queue_match.group(1)
+
+            owner_match = re.search(r'Job_Owner = (.+)@', line)
+            if owner_match:
+                current_job['user'] = owner_match.group(1)
+
+            state_match = re.search(r'job_state = ([A-Z])', line)
+            if state_match:
+                current_job['state'] = state_match.group(1)
+
+            qtime_match = re.search(r'qtime = (.+)', line)
+            if qtime_match:
+                try:
+                    dt = datetime.strptime(qtime_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
+                    current_job['qtime'] = int(dt.timestamp())
+                except ValueError:
+                    pass
+
+            stime_match = re.search(r'stime = (.+)', line)
+            if stime_match:
+                try:
+                    dt = datetime.strptime(stime_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
+                    current_job['start_time'] = int(dt.timestamp())
+                except ValueError:
+                    pass
+
+            obit_match = re.search(r'obittime = (.+)', line)
+            if obit_match:
+                try:
+                    dt = datetime.strptime(obit_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
+                    current_job['obittime'] = int(dt.timestamp())
+                except ValueError:
+                    pass
+
+            mtime_match = re.search(r'mtime = (.+)', line)
+            if mtime_match:
+                try:
+                    dt = datetime.strptime(mtime_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
+                    current_job['mtime'] = int(dt.timestamp())
+                except ValueError:
+                    pass
+
+            if 'resources_used' in line or 'Resource_List' in line:
+                cpu_match = re.search(r'Resource_List.ncpus = (\d+)', line)
+                if cpu_match:
+                    current_job['ncpus'] = int(cpu_match.group(1))
+
+                cpu_match = re.search(r'resources_used.cpupercent = (\d+)', line)
+                if cpu_match:
+                    current_job['cpupercent'] = int(cpu_match.group(1))
+
+                ncpus_used_match = re.search(r'resources_used.ncpus = (\d+)', line)
+                if ncpus_used_match:
+                    current_job['ncpus_used'] = int(ncpus_used_match.group(1))
+
+                if 'resources_used.mem' in line:
+                    mem_match1 = re.search(r'resources_used.mem = (\d+)kb', line)
+                    mem_match2 = re.search(r'resources_used.mem = (\d+)gb', line)
+                    mem_match3 = re.search(r'resources_used.mem = 0b', line)
+                    if mem_match1:
+                        current_job['mem_usage'] = int(mem_match1.group(1))
+                    elif mem_match2:
+                        current_job['mem_usage'] = int(mem_match2.group(1)) * 1024 * 1024
+                    elif mem_match3:
+                        current_job['mem_usage'] = 0
+                    else:
+                        raise Exception("Unknown memory unit from line: " + line)
+
+                mem_req_match = re.search(r'Resource_List.mem = (\d+)([a-zA-Z]+)', line)
+                if mem_req_match:
+                    val = int(mem_req_match.group(1))
+                    unit = mem_req_match.group(2).lower()
+                    if unit == 'gb':
+                        mem_gb = val
+                    elif unit == 'mb':
+                        mem_gb = val / 1024
+                    elif unit == 'kb':
+                        mem_gb = val / (1024 * 1024)
+                    else:
+                        mem_gb = 0
+                    current_job['mem_request_gb'] = mem_gb
+
+                gpu_match = re.search(r'Resource_List.ngpus = (\d+)', line)
+                if gpu_match:
+                    current_job['ngpus'] = int(gpu_match.group(1))
+
+                walltime_match = re.search(r'resources_used.walltime = (\d+):(\d+):(\d+)', line)
+                if walltime_match:
+                    h, m, s = map(int, walltime_match.groups())
+                    current_job['walltime_used'] = h * 3600 + m * 60 + s
+                    if 'walltime_total' in current_job:
+                        current_job['walltime'] = current_job['walltime_total'] - current_job['walltime_used']
+
+                cput_match = re.search(r'resources_used.cput = (\d+):(\d+):(\d+)', line)
+                if cput_match:
+                    h, m, s = map(int, cput_match.groups())
+                    current_job['cput_used'] = h * 3600 + m * 60 + s
+
+                vmem_match = re.search(r'resources_used.vmem = (\d+)([a-zA-Z]+)', line)
+                if vmem_match:
+                    val = int(vmem_match.group(1))
+                    unit = vmem_match.group(2).lower()
+                    if unit == 'kb':
+                        vmem_kb = val
+                    elif unit == 'mb':
+                        vmem_kb = val * 1024
+                    elif unit == 'gb':
+                        vmem_kb = val * 1024 * 1024
+                    else:
+                        vmem_kb = 0
+                    current_job['vmem_used_kb'] = vmem_kb
+
+                walltime_match = re.search(r'Resource_List.walltime = (\d+):(\d+):(\d+)', line)
+                if walltime_match:
+                    h, m, s = map(int, walltime_match.groups())
+                    requested_walltime = h * 3600 + m * 60 + s
+                    current_job['walltime_total'] = requested_walltime
+                    if 'walltime_used' in current_job:
+                        current_job['walltime'] = requested_walltime - current_job['walltime_used']
+                    else:
+                        current_job['walltime'] = requested_walltime
+                    current_job['cpu_usage_remaining'] = current_job['ncpus'] * current_job['walltime']
+                    if 'ngpus' in current_job:
+                        current_job['gpu_usage_remaining'] = current_job['ngpus'] * current_job['walltime']
+
+            exit_match = re.search(r'Exit_status = (\d+)', line)
+            if exit_match:
+                current_job['exit_status'] = int(exit_match.group(1))
+
+        if current_job:
+            jobs.append(current_job)
+        return jobs
+
     if path is None:
         path = os.environ.get("MQSTAT_QSTAT_F")
     if path:
         with open(path) as f:
             output = f.read()
-    else:
-        # Full format for detailed information
-        # Add -t to expand job arrays into individual jobs
-        cmd = "qstat -f -t"
-        if include_history:
-            cmd = "qstat -xf -t"
+        return _parse(output)
+
+    limit_marker = "AWK_LIMIT_REACHED"
+    cmd_active = "qstat -f -t"
+    if max_jobs:
+        cmd_active = (
+            f"{cmd_active} | awk '/Job Id:/{{if (count++=={max_jobs}) {{print \"{limit_marker}\"; exit}}}} {{print}}'"
+        )
+    active_out = run_command(cmd_active)
+    if not active_out:
+        return []
+    lines = active_out.splitlines()
+    if lines and lines[-1] == limit_marker:
+        parse_qstat.limit_hit = True
+        lines = lines[:-1]
+    active_jobs = _parse("\n".join(lines))
+    job_dict = {j['id']: j for j in active_jobs}
+
+    if include_history:
+        cmd_hist = "qstat -xf -t"
         if max_jobs:
-            # Limit the number of jobs returned to speed up queries on large clusters
-            cmd = (
-                f"qstat -{'x' if include_history else ''}f | "
-                f"awk '/Job Id:/{{if (count++=={max_jobs}) exit}} {{print}}'"
+            cmd_hist = (
+                f"{cmd_hist} | awk '/Job Id:/{{if (count++=={max_jobs}) exit}} {{print}}'"
             )
-        output = run_command(cmd)
-        if not output:
-            return []
+        hist_out = run_command(cmd_hist) or ""
+        for job in _parse(hist_out):
+            job_dict.setdefault(job['id'], job)
 
-    jobs = []
-    current_job = None
-
-    for line in output.splitlines():
-        # Match job ID line
-        job_match = re.match(r'^Job Id: (.+)$', line)
-        if job_match:
-            if current_job:
-                jobs.append(current_job)
-            current_job = {'id': job_match.group(1), 'user': None, 'ncpus': 0,
-                           'cpu_usage': 0, 'mem_usage': 0, 'gpu_usage': 0,
-                           'state': None}
-            continue
-
-        if not current_job:
-            continue
-
-        # Match job name
-        name_match = re.search(r'Job_Name = (.+)', line)
-        if name_match:
-            current_job['name'] = name_match.group(1)
-
-        # Match queue
-        queue_match = re.search(r'queue = (.+)', line)
-        if queue_match:
-            current_job['queue'] = queue_match.group(1)
-
-        # Match job owner
-        owner_match = re.search(r'Job_Owner = (.+)@', line)
-        if owner_match:
-            current_job['user'] = owner_match.group(1)
-
-        # Match job state
-        state_match = re.search(r'job_state = ([A-Z])', line)
-        if state_match:
-            current_job['state'] = state_match.group(1)
-
-        # Queue and start times
-        qtime_match = re.search(r'qtime = (.+)', line)
-        if qtime_match:
-            try:
-                dt = datetime.strptime(qtime_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
-                current_job['qtime'] = int(dt.timestamp())
-            except ValueError:
-                pass
-
-        stime_match = re.search(r'stime = (.+)', line)
-        if stime_match:
-            try:
-                dt = datetime.strptime(stime_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
-                current_job['start_time'] = int(dt.timestamp())
-            except ValueError:
-                pass
-
-        # Finished time
-        obit_match = re.search(r'obittime = (.+)', line)
-        if obit_match:
-            try:
-                dt = datetime.strptime(obit_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
-                current_job['obittime'] = int(dt.timestamp())
-            except ValueError:
-                pass
-
-        mtime_match = re.search(r'mtime = (.+)', line)
-        if mtime_match:
-            try:
-                dt = datetime.strptime(mtime_match.group(1).strip(), "%a %b %d %H:%M:%S %Y")
-                current_job['mtime'] = int(dt.timestamp())
-            except ValueError:
-                pass
-
-        # Match resource usage and requests
-        if 'resources_used' in line or 'Resource_List' in line:
-            # ncpus requested
-            cpu_match = re.search(r'Resource_List.ncpus = (\d+)', line)
-            if cpu_match:
-                current_job['ncpus'] = int(cpu_match.group(1))
-
-            # CPU percentage
-            cpu_match = re.search(r'resources_used.cpupercent = (\d+)', line)
-            if cpu_match:
-                current_job['cpupercent'] = int(cpu_match.group(1))
-
-            ncpus_used_match = re.search(r'resources_used.ncpus = (\d+)', line)
-            if ncpus_used_match:
-                current_job['ncpus_used'] = int(ncpus_used_match.group(1))
-
-            # Memory usage
-            if 'resources_used.mem' in line:
-                mem_match1 = re.search(r'resources_used.mem = (\d+)kb', line)
-                mem_match2 = re.search(r'resources_used.mem = (\d+)gb', line)
-                mem_match3 = re.search(r'resources_used.mem = 0b', line)
-                if mem_match1:
-                    current_job['mem_usage'] = int(mem_match1.group(1))
-                elif mem_match2:
-                    current_job['mem_usage'] = int(mem_match2.group(1)) * 1024 * 1024
-                elif mem_match3:
-                    current_job['mem_usage'] = 0
-                else:
-                    raise Exception("Unknown memory unit from line: " + line)
-
-            # Memory requested
-            mem_req_match = re.search(r'Resource_List.mem = (\d+)([a-zA-Z]+)', line)
-            if mem_req_match:
-                val = int(mem_req_match.group(1))
-                unit = mem_req_match.group(2).lower()
-                if unit == 'gb':
-                    mem_gb = val
-                elif unit == 'mb':
-                    mem_gb = val / 1024
-                elif unit == 'kb':
-                    mem_gb = val / (1024 * 1024)
-                else:
-                    mem_gb = 0
-                current_job['mem_request_gb'] = mem_gb
-
-            # GPU
-            gpu_match = re.search(r'Resource_List.ngpus = (\d+)', line)
-            if gpu_match:
-                current_job['ngpus'] = int(gpu_match.group(1))
-
-            # walltime used
-            walltime_match = re.search(r'resources_used.walltime = (\d+):(\d+):(\d+)', line)
-            if walltime_match:
-                h, m, s = map(int, walltime_match.groups())
-                current_job['walltime_used'] = h * 3600 + m * 60 + s
-                if 'walltime_total' in current_job:
-                    current_job['walltime'] = current_job['walltime_total'] - current_job['walltime_used']
-
-            # CPU time used
-            cput_match = re.search(r'resources_used.cput = (\d+):(\d+):(\d+)', line)
-            if cput_match:
-                h, m, s = map(int, cput_match.groups())
-                current_job['cput_used'] = h * 3600 + m * 60 + s
-
-            # vmem used
-            vmem_match = re.search(r'resources_used.vmem = (\d+)([a-zA-Z]+)', line)
-            if vmem_match:
-                val = int(vmem_match.group(1))
-                unit = vmem_match.group(2).lower()
-                if unit == 'kb':
-                    vmem_kb = val
-                elif unit == 'mb':
-                    vmem_kb = val * 1024
-                elif unit == 'gb':
-                    vmem_kb = val * 1024 * 1024
-                else:
-                    vmem_kb = 0
-                current_job['vmem_used_kb'] = vmem_kb
-
-            # Requested walltime
-            walltime_match = re.search(r'Resource_List.walltime = (\d+):(\d+):(\d+)', line)
-            if walltime_match:
-                h, m, s = map(int, walltime_match.groups())
-                requested_walltime = h * 3600 + m * 60 + s
-                current_job['walltime_total'] = requested_walltime
-                # Deduct the time already used, if already running
-                if 'walltime_used' in current_job:
-                    current_job['walltime'] = requested_walltime - current_job['walltime_used']
-                else:
-                    current_job['walltime'] = requested_walltime
-                # The true cpu time ncpus * walltime
-                current_job['cpu_usage_remaining'] = current_job['ncpus'] * current_job['walltime']
-                # gpus
-                if 'ngpus' in current_job:
-                    current_job['gpu_usage_remaining'] = current_job['ngpus'] * current_job['walltime']
-        exit_match = re.search(r'Exit_status = (\d+)', line)
-        if exit_match:
-            current_job['exit_status'] = int(exit_match.group(1))
-
-    # Add the last job
-    if current_job:
-        jobs.append(current_job)
-
-    return jobs
+    return list(job_dict.values())
 
 def get_job_status_counts(jobs):
     """Count jobs by status (running, queued, held)."""
@@ -755,6 +750,9 @@ def job_table(jobs, finished=False):
                 r[15].ljust(note_w),
             ]
             lines.append("  ".join(parts))
+        if parse_qstat.limit_hit:
+            warning = f"{Colors.BOLD}{Colors.RED}WARNING: job list truncated; running/queued jobs may be missing{Colors.ENDC}"
+            lines.insert(0, warning)
         return lines
     else:
         cpu_w = max(len(headers[5]), max(len(str(r[5])) for r in rows))
@@ -790,6 +788,9 @@ def job_table(jobs, finished=False):
                 r[11].ljust(note_w),
             ]
             lines.append("  ".join(parts))
+        if parse_qstat.limit_hit:
+            warning = f"{Colors.BOLD}{Colors.RED}WARNING: job list truncated; running/queued jobs may be missing{Colors.ENDC}"
+            lines.insert(0, warning)
         return lines
 
 

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -445,19 +445,27 @@ def main() -> None:
                 refresh = False
 
             stdscr.erase()
+            warning = None
+            if mqstat.parse_qstat.limit_hit:
+                warning = "\x1b[1m\x1b[91mWARNING: job list truncated; running/queued jobs may be missing\x1b[0m"
             page = maxy - 2
             if lines:
                 max_sel = len(lines) - 1
                 selected = min(max(1, selected), max_sel)
-                offset = max(0, min(offset, max_sel - page))
+                vis_rows = page - (1 if warning else 0)
+                offset = max(0, min(offset, max_sel - vis_rows))
                 if selected < offset + 1:
                     offset = selected - 1
-                elif selected > offset + page:
-                    offset = selected - page
-                draw_line(stdscr, 0, lines[0], maxx, highlight=True)
-                visible = lines[1 + offset : 1 + offset + page]
-                for i, line in enumerate(visible, start=1):
-                    draw_line(stdscr, i, line, maxx, highlight=(offset + i == selected))
+                elif selected > offset + vis_rows:
+                    offset = selected - vis_rows
+                y = 0
+                if warning:
+                    draw_line(stdscr, 0, warning, maxx)
+                    y = 1
+                draw_line(stdscr, y, lines[0], maxx, highlight=True)
+                visible = lines[1 + offset : 1 + offset + vis_rows]
+                for i, line in enumerate(visible, start=y + 1):
+                    draw_line(stdscr, i, line, maxx, highlight=(offset + i - y == selected))
             else:
                 offset = 0
                 selected = 1

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -173,7 +173,12 @@ def format_jobs(jobs, now=None):
 
         note = ""
         if state not in ("C", "F"):
-            if cpupercent is not None and ncpus_used and cpupercent < ncpus_used * 10:
+            if (
+                not short_run
+                and cpupercent is not None
+                and ncpus_used
+                and cpupercent < ncpus_used * 10
+            ):
                 note = "❗ <10% of CPU used"
         else:
             if used_s < 60:

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -115,6 +115,7 @@ def format_jobs(jobs, now=None):
         "progress",
         "walltime",
         "waited",
+        "age",
         "CPU",
         "cpu%",
         "RAM(G)",
@@ -138,8 +139,17 @@ def format_jobs(jobs, now=None):
         waited = ""
         qtime = job.get("qtime")
         start_time = job.get("start_time")
-        if qtime and start_time and start_time > qtime:
-            waited = mqstat.format_hm(start_time - qtime)
+        state = job.get("state", "")
+        if state == "Q" and qtime:
+            waited = mqstat.format_hm(max(0, now - qtime))
+        elif qtime and start_time:
+            waited = mqstat.format_hm(max(0, start_time - qtime))
+
+        age = ""
+        if state in ("C", "F"):
+            ft = job.get("obittime") or job.get("mtime")
+            if ft:
+                age = mqstat.format_hm(max(0, int(now - ft)))
 
         cpu = job.get("ncpus", 0)
         cpupercent = job.get("cpupercent")
@@ -161,7 +171,6 @@ def format_jobs(jobs, now=None):
         ram_util_str = f"{int(ram_util)}%" if ram_util else ""
         ram_low = ram_util and ram_util < 10
 
-        state = job.get("state", "")
         note = ""
         if state not in ("C", "F"):
             if cpupercent is not None and ncpus_used and cpupercent < ncpus_used * 10:
@@ -209,6 +218,7 @@ def format_jobs(jobs, now=None):
                 "bar": bar,
                 "wall": total,
                 "waited": waited,
+                "age": age,
                 "cpu": str(cpu),
                 "cpu_util": cpu_field,
                 "ram": str(ram),
@@ -229,13 +239,14 @@ def format_jobs(jobs, now=None):
     time_w = len(headers[2])
     wall_w = max(len(headers[4]), max(visible_len(r["wall"]) for r in rows))
     wait_w = max(len(headers[5]), max(visible_len(r["waited"]) for r in rows))
-    cpu_w = max(len(headers[6]), max(visible_len(r["cpu"]) for r in rows))
-    cpuu_w = max(len(headers[7]), max(visible_len(r["cpu_util"]) for r in rows))
-    ram_w = max(len(headers[8]), max(visible_len(r["ram"]) for r in rows))
-    ramu_w = max(len(headers[9]), max(visible_len(r["ram_util"]) for r in rows))
-    state_w = max(len(headers[10]), max(visible_len(r["state"]) for r in rows))
-    queue_w = max(len(headers[11]), max(visible_len(r["queue"]) for r in rows))
-    note_w = max(len(headers[12]), max(visible_len(r["note"]) for r in rows))
+    age_w = max(len(headers[6]), max(visible_len(r["age"]) for r in rows))
+    cpu_w = max(len(headers[7]), max(visible_len(r["cpu"]) for r in rows))
+    cpuu_w = max(len(headers[8]), max(visible_len(r["cpu_util"]) for r in rows))
+    ram_w = max(len(headers[9]), max(visible_len(r["ram"]) for r in rows))
+    ramu_w = max(len(headers[10]), max(visible_len(r["ram_util"]) for r in rows))
+    state_w = max(len(headers[11]), max(visible_len(r["state"]) for r in rows))
+    queue_w = max(len(headers[12]), max(visible_len(r["queue"]) for r in rows))
+    note_w = max(len(headers[13]), max(visible_len(r["note"]) for r in rows))
 
     header_parts = [
         headers[0].ljust(id_w),
@@ -244,13 +255,14 @@ def format_jobs(jobs, now=None):
         headers[3].ljust(20),
         headers[4].ljust(wall_w),
         headers[5].ljust(wait_w),
-        headers[6].rjust(cpu_w),
-        headers[7].rjust(cpuu_w),
-        headers[8].rjust(ram_w),
-        headers[9].rjust(ramu_w),
-        headers[10].ljust(state_w),
-        headers[11].ljust(queue_w),
-        headers[12].ljust(note_w),
+        headers[6].ljust(age_w),
+        headers[7].rjust(cpu_w),
+        headers[8].rjust(cpuu_w),
+        headers[9].rjust(ram_w),
+        headers[10].rjust(ramu_w),
+        headers[11].ljust(state_w),
+        headers[12].ljust(queue_w),
+        headers[13].ljust(note_w),
     ]
     lines = ["  ".join(header_parts)]
 
@@ -262,6 +274,7 @@ def format_jobs(jobs, now=None):
             r["bar"],
             ljust_ansi(r["wall"], wall_w),
             ljust_ansi(r["waited"], wait_w),
+            ljust_ansi(r["age"], age_w),
             rjust_ansi(r["cpu"], cpu_w),
             rjust_ansi(r["cpu_util"], cpuu_w),
             rjust_ansi(r["ram"], ram_w),
@@ -326,6 +339,7 @@ def main() -> None:
         offset = 0  # topmost job line displayed (0-based)
         lines, job_rows = [], []
         refresh = True
+        show_queued = True
 
         while True:
             maxy, maxx = stdscr.getmaxyx()
@@ -421,18 +435,25 @@ def main() -> None:
                             break
             elif key == ord("r"):
                 refresh = True
+            elif key == ord("u"):
+                show_queued = not show_queued
+                refresh = True
 
             if refresh:
                 jobs = get_jobs(include_history=True)
                 now = time.time()
                 running = []
+                queued = []
                 for job in jobs:
                     if job.get("queue") == "cpu_inter_exec":
                         continue
-                    if job.get("state") in ("C", "F"):
+                    state = job.get("state")
+                    if state in ("C", "F"):
                         ft = job.get("obittime") or job.get("mtime", now)
                         if now - ft <= 24 * 3600:
                             finished[job["id"]] = job
+                    elif state == "Q":
+                        queued.append(job)
                     else:
                         running.append(job)
                 for jid, job in list(finished.items()):
@@ -440,14 +461,19 @@ def main() -> None:
                     if now - ft > 24 * 3600 or job.get("queue") == "cpu_inter_exec":
                         finished.pop(jid, None)
 
-                all_jobs = running + list(finished.values())
+                running.sort(key=lambda j: j.get("walltime_used", 0), reverse=True)
+                queued.sort(key=lambda j: now - j.get("qtime", now), reverse=True)
+                finished_jobs = sorted(
+                    finished.values(), key=lambda j: j.get("obittime") or j.get("mtime", 0), reverse=True
+                )
+                all_jobs = running + (queued if show_queued else []) + finished_jobs
                 lines, job_rows = format_jobs(all_jobs, now=now)
                 refresh = False
 
             stdscr.erase()
             warning = None
             if mqstat.parse_qstat.limit_hit:
-                warning = "\x1b[1m\x1b[91mWARNING: job list truncated; running/queued jobs may be missing\x1b[0m"
+                warning = "\x1b[91mWARNING: job list truncated; increase --max-jobs to see more running/queued jobs\x1b[0m"
             page = maxy - 2
             if lines:
                 max_sel = len(lines) - 1
@@ -469,7 +495,7 @@ def main() -> None:
             else:
                 offset = 0
                 selected = 1
-            help_text = "q quit  / search  o stdout  e stderr  f full  s ssh  r refresh"
+            help_text = "q quit  / search  o stdout  e stderr  f full  s ssh  r refresh  u toggle queued"
             addstr_safe(stdscr, maxy - 1, 0, help_text, maxx)
             stdscr.refresh()
             time.sleep(0.1)

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -288,10 +288,20 @@ def format_jobs(jobs, now=None):
 def main() -> None:
     parser = argparse.ArgumentParser(description="Interactive job viewer")
     parser.add_argument("--qstat-file", help="Use qstat -f output from file", default=None)
+    parser.add_argument(
+        "--max-jobs",
+        type=int,
+        default=500,
+        help="Maximum number of jobs to load",
+    )
     args = parser.parse_args()
 
     def get_jobs(include_history: bool = False):
-        return mqstat.parse_qstat(path=args.qstat_file, include_history=include_history)
+        return mqstat.parse_qstat(
+            path=args.qstat_file,
+            include_history=include_history,
+            max_jobs=args.max_jobs,
+        )
 
     def _draw(stdscr):
         curses.curs_set(0)

--- a/tests/test_mqstat.py
+++ b/tests/test_mqstat.py
@@ -234,6 +234,28 @@ def test_job_table_zero_waited():
     assert row[5] == "00:00"
 
 
+def test_job_table_running_short_runtime_no_note():
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "bin" / "mqstat"
+    import runpy
+    mod = runpy.run_path(str(script))
+    mod['parse_qstat'].limit_hit = False
+    job = {
+        'id': '1',
+        'name': 'short',
+        'walltime_used': 60,
+        'walltime_total': 120,
+        'ncpus': 4,
+        'cpupercent': 20,
+        'ncpus_used': 4,
+        'mem_request_gb': 1,
+        'state': 'R'
+    }
+    lines = mod['job_table']([job])
+    row = split_cols(lines[1])
+    assert row[-1] == ""
+
+
 def test_watch_jobs_no_curses_error(monkeypatch):
     repo = Path(__file__).resolve().parents[1]
     script = repo / "bin" / "mqstat"

--- a/tests/test_mqtop.py
+++ b/tests/test_mqtop.py
@@ -1,5 +1,6 @@
 import runpy
 from pathlib import Path
+import runpy
 
 
 def test_format_jobs_has_superset_columns():
@@ -37,7 +38,7 @@ def test_format_jobs_has_superset_columns():
 
     lines, rows = mod["format_jobs"](jobs)
     header = lines[0]
-    for col in ["waited", "cpu%", "ram%", "state"]:
+    for col in ["waited", "age", "cpu%", "ram%", "state"]:
         assert col in header
     assert len(rows) == 2
 

--- a/tests/test_mqtop.py
+++ b/tests/test_mqtop.py
@@ -1,6 +1,15 @@
 import runpy
 from pathlib import Path
 import runpy
+import re
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def split_cols(line):
+    line = ANSI.sub('', line.rstrip('\n'))
+    parts = re.split(r"\s{2,}", line)
+    return [p.strip() for p in parts]
 
 
 def test_format_jobs_has_superset_columns():
@@ -66,4 +75,6 @@ def test_short_runtime_not_coloured_red():
 
     lines, _ = mod["format_jobs"](jobs)
     assert "\033[91m" not in lines[1]
+    row = split_cols(lines[1])
+    assert row[-1] == ""
 


### PR DESCRIPTION
## Summary
- add `--max-jobs` option (default 500) to mqtop
- allow `parse_qstat` to cap jobs via awk when `max_jobs` is set
- document flag in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab98ead110832a814f76309745e1b8