### PR TITLE
Add timed auto-refresh to mqtop

### DIFF
--- a/bin/mqtop
+++ b/bin/mqtop
@@ -36,6 +36,27 @@ ansi_re = re.compile(r"\x1b\[(\d+)m(.*?)\x1b\[0m")
 # basic ANSI colour escapes used for row colouring
 ORANGE = "\033[33m"
 
+# Automatically refresh the job table every 10 minutes (in seconds)
+REFRESH_INTERVAL = 10 * 60
+
+
+def refresh_due(last_refresh: float, now: float | None = None, interval: int = REFRESH_INTERVAL) -> bool:
+    """Return ``True`` if a refresh should occur.
+
+    Parameters
+    ----------
+    last_refresh:
+        Timestamp of the most recent refresh.
+    now:
+        Current timestamp. Defaults to ``time.time()``.
+    interval:
+        Refresh interval in seconds. Defaults to :data:`REFRESH_INTERVAL`.
+    """
+
+    if now is None:
+        now = time.time()
+    return now - last_refresh >= interval
+
 
 def strip_ansi(text: str) -> str:
     """Return *text* with ANSI colour escapes removed."""
@@ -345,10 +366,14 @@ def main() -> None:
         lines, job_rows = [], []
         refresh = True
         show_queued = True
+        last_refresh = 0.0
 
         while True:
             maxy, maxx = stdscr.getmaxyx()
             key = stdscr.getch()
+            if refresh_due(last_refresh):
+                refresh = True
+
             if key == ord("q"):
                 break
             elif key == curses.KEY_MOUSE:
@@ -473,6 +498,7 @@ def main() -> None:
                 )
                 all_jobs = running + (queued if show_queued else []) + finished_jobs
                 lines, job_rows = format_jobs(all_jobs, now=now)
+                last_refresh = time.time()
                 refresh = False
 
             stdscr.erase()

--- a/tests/test_mqtop.py
+++ b/tests/test_mqtop.py
@@ -1,6 +1,5 @@
 import runpy
 from pathlib import Path
-import runpy
 import re
 
 ANSI = re.compile(r"\x1b\[[0-9;]*m")
@@ -77,4 +76,17 @@ def test_short_runtime_not_coloured_red():
     assert "\033[91m" not in lines[1]
     row = split_cols(lines[1])
     assert row[-1] == ""
+
+
+def test_refresh_due():
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "bin" / "mqtop"
+    mod = runpy.run_path(str(script))
+
+    assert not mod["refresh_due"](0, now=599)
+    assert mod["refresh_due"](0, now=600)
+
+    last = 600
+    assert not mod["refresh_due"](last, now=last + 599)
+    assert mod["refresh_due"](last, now=last + 600)
 


### PR DESCRIPTION
## Summary
- refresh mqtop job table every 10 minutes automatically
- reset timer when manually refreshing with `r`
- test refresh timer logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac0bb47460832a87837e6af5324f3b