### PR TITLE
Invert mqtop help row and warn on invalid key presses

### DIFF
--- a/bin/mqstat
+++ b/bin/mqstat
@@ -116,6 +116,7 @@ def parse_qstat(path=None, include_history=False, max_jobs=None):
     """Parse qstat output and merge active and historical jobs."""
 
     parse_qstat.limit_hit = False
+    parse_qstat.hist_limit_hit = False
 
     def _parse(output):
         jobs = []
@@ -296,10 +297,14 @@ def parse_qstat(path=None, include_history=False, max_jobs=None):
         cmd_hist = "qstat -xf -t"
         if max_jobs:
             cmd_hist = (
-                f"{cmd_hist} | awk '/Job Id:/{{if (count++=={max_jobs}) exit}} {{print}}'"
+                f"{cmd_hist} | awk '/Job Id:/{{if (count++=={max_jobs}) {{print \"{limit_marker}\"; exit}}}} {{print}}'"
             )
         hist_out = run_command(cmd_hist) or ""
-        for job in _parse(hist_out):
+        lines = hist_out.splitlines()
+        if lines and lines[-1] == limit_marker:
+            parse_qstat.hist_limit_hit = True
+            lines = lines[:-1]
+        for job in _parse("\n".join(lines)):
             job_dict.setdefault(job['id'], job)
 
     return list(job_dict.values())
@@ -759,8 +764,17 @@ def job_table(jobs, finished=False):
                 r[16].ljust(note_w),
             ]
             lines.append("  ".join(parts))
+        messages = []
         if parse_qstat.limit_hit:
-            warning = f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more running/queued jobs{Colors.ENDC}"
+            messages.append("running/queued jobs")
+        if getattr(parse_qstat, "hist_limit_hit", False):
+            messages.append("finished jobs")
+        if messages:
+            warning = (
+                f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more "
+                + " and ".join(messages)
+                + f"{Colors.ENDC}"
+            )
             lines.insert(0, warning)
         return lines
     else:
@@ -797,8 +811,17 @@ def job_table(jobs, finished=False):
                 r[11].ljust(note_w),
             ]
             lines.append("  ".join(parts))
+        messages = []
         if parse_qstat.limit_hit:
-            warning = f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more running/queued jobs{Colors.ENDC}"
+            messages.append("running/queued jobs")
+        if getattr(parse_qstat, "hist_limit_hit", False):
+            messages.append("finished jobs")
+        if messages:
+            warning = (
+                f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more "
+                + " and ".join(messages)
+                + f"{Colors.ENDC}"
+            )
             lines.insert(0, warning)
         return lines
 

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -284,9 +284,7 @@ def parse_qstat(path=None, include_history=False, max_jobs=None):
         cmd_active = (
             f"{cmd_active} | awk '/Job Id:/{{if (count++=={max_jobs}) {{print \"{limit_marker}\"; exit}}}} {{print}}'"
         )
-    active_out = run_command(cmd_active)
-    if not active_out:
-        return []
+    active_out = run_command(cmd_active) or ""
     lines = active_out.splitlines()
     if lines and lines[-1] == limit_marker:
         parse_qstat.limit_hit = True

--- a/bin/mqstat
+++ b/bin/mqstat
@@ -764,18 +764,18 @@ def job_table(jobs, finished=False):
                 r[16].ljust(note_w),
             ]
             lines.append("  ".join(parts))
-        messages = []
+        warnings = []
         if parse_qstat.limit_hit:
-            messages.append("running/queued jobs")
-        if getattr(parse_qstat, "hist_limit_hit", False):
-            messages.append("finished jobs")
-        if messages:
-            warning = (
-                f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more "
-                + " and ".join(messages)
-                + f"{Colors.ENDC}"
+            warnings.append(
+                f"{Colors.RED}WARNING: qstat -f may not have returned all running/queued jobs; "
+                f"increase --max-jobs{Colors.ENDC}"
             )
-            lines.insert(0, warning)
+        if getattr(parse_qstat, "hist_limit_hit", False):
+            warnings.append(
+                f"{Colors.RED}WARNING: qstat -xf may not have returned all finished jobs; "
+                f"increase --max-jobs{Colors.ENDC}"
+            )
+        lines = warnings + lines
         return lines
     else:
         cpu_w = max(len(headers[5]), max(len(str(r[5])) for r in rows))
@@ -811,19 +811,18 @@ def job_table(jobs, finished=False):
                 r[11].ljust(note_w),
             ]
             lines.append("  ".join(parts))
-        messages = []
+        warnings = []
         if parse_qstat.limit_hit:
-            messages.append("running/queued jobs")
-        if getattr(parse_qstat, "hist_limit_hit", False):
-            messages.append("finished jobs")
-        if messages:
-            warning = (
-                f"{Colors.RED}WARNING: job list truncated; increase --max-jobs to see more "
-                + " and ".join(messages)
-                + f"{Colors.ENDC}"
+            warnings.append(
+                f"{Colors.RED}WARNING: qstat -f may not have returned all running/queued jobs; "
+                f"increase --max-jobs{Colors.ENDC}"
             )
-            lines.insert(0, warning)
-        return lines
+        if getattr(parse_qstat, "hist_limit_hit", False):
+            warnings.append(
+                f"{Colors.RED}WARNING: qstat -xf may not have returned all finished jobs; "
+                f"increase --max-jobs{Colors.ENDC}"
+            )
+        return warnings + lines
 
 
 def list_jobs(jobs):

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -340,7 +340,9 @@ def format_jobs(jobs, now=None):
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Interactive job viewer")
-    parser.add_argument("--qstat-file", help="Use qstat -f output from file", default=None)
+    parser.add_argument("--qstat-f-file", help="Use qstat -f output from file", default=None)
+    parser.add_argument("--qstat-xf-file", help="Use qstat -xf output from file", default=None)
+    parser.add_argument("--qstat-file", help=argparse.SUPPRESS, default=None)
     parser.add_argument(
         "--max-jobs",
         type=int,
@@ -354,9 +356,18 @@ def main() -> None:
     )
     args = parser.parse_args()
 
+    if args.qstat_file and not args.qstat_f_file:
+        args.qstat_f_file = args.qstat_file
+
     def get_jobs(include_history: bool = False):
+        if args.qstat_f_file or args.qstat_xf_file:
+            active = mqstat.parse_qstat(path=args.qstat_f_file) if args.qstat_f_file else []
+            hist = mqstat.parse_qstat(path=args.qstat_xf_file) if args.qstat_xf_file else []
+            job_dict = {j["id"]: j for j in active}
+            for job in hist:
+                job_dict.setdefault(job["id"], job)
+            return list(job_dict.values())
         return mqstat.parse_qstat(
-            path=args.qstat_file,
             include_history=include_history,
             max_jobs=args.max_jobs,
         )
@@ -372,13 +383,16 @@ def main() -> None:
                 continue
             state = job.get("state")
             if state in ("C", "F"):
-                ft = job.get("obittime") or job.get("mtime", now)
-                if now - ft <= 24 * 3600:
-                    finished[job["id"]] = job
+                finished[job["id"]] = job
             elif state == "Q":
                 queued.append(job)
             else:
                 running.append(job)
+        if running or queued:
+            for jid, job in list(finished.items()):
+                ft = job.get("obittime") or job.get("mtime", now)
+                if now - ft > 24 * 3600:
+                    finished.pop(jid, None)
         running.sort(key=lambda j: j.get("walltime_used", 0), reverse=True)
         queued.sort(key=lambda j: now - j.get("qtime", now), reverse=True)
         finished_jobs = sorted(
@@ -552,16 +566,18 @@ def main() -> None:
                         continue
                     state = job.get("state")
                     if state in ("C", "F"):
-                        ft = job.get("obittime") or job.get("mtime", now)
-                        if now - ft <= 24 * 3600:
-                            finished[job["id"]] = job
+                        finished[job["id"]] = job
                     elif state == "Q":
                         queued.append(job)
                     else:
                         running.append(job)
+                if running or queued:
+                    for jid, job in list(finished.items()):
+                        ft = job.get("obittime") or job.get("mtime", now)
+                        if now - ft > 24 * 3600:
+                            finished.pop(jid, None)
                 for jid, job in list(finished.items()):
-                    ft = job.get("obittime") or job.get("mtime", now)
-                    if now - ft > 24 * 3600 or job.get("queue") == "cpu_inter_exec":
+                    if job.get("queue") == "cpu_inter_exec":
                         finished.pop(jid, None)
 
                 running.sort(key=lambda j: j.get("walltime_used", 0), reverse=True)

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -606,8 +606,17 @@ def main() -> None:
 
             stdscr.erase()
             warning = None
-            if mqstat.parse_qstat.limit_hit:
-                warning = "\x1b[91mWARNING: job list truncated; increase --max-jobs to see more running/queued jobs\x1b[0m"
+            if mqstat.parse_qstat.limit_hit or getattr(mqstat.parse_qstat, "hist_limit_hit", False):
+                parts = []
+                if mqstat.parse_qstat.limit_hit:
+                    parts.append("running/queued jobs")
+                if getattr(mqstat.parse_qstat, "hist_limit_hit", False):
+                    parts.append("finished jobs")
+                warning = (
+                    "\x1b[91mWARNING: job list truncated; increase --max-jobs to see more "
+                    + " and ".join(parts)
+                    + "\x1b[0m"
+                )
             page = maxy - 3
             if lines:
                 max_sel = len(lines) - 1

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -400,6 +400,13 @@ def main() -> None:
         )
         all_jobs = running + queued + finished_jobs
         lines, _ = format_jobs(all_jobs, now=now)
+        warnings = []
+        if mqstat.parse_qstat.limit_hit:
+            warnings.append("qstat -f may not have returned all running/queued jobs")
+        if getattr(mqstat.parse_qstat, "hist_limit_hit", False):
+            warnings.append("qstat -xf may not have returned all finished jobs")
+        for w in warnings:
+            print(f"\x1b[91mWARNING: {w}; increase --max-jobs\x1b[0m")
         for line in lines[:24]:
             print(line)
         return
@@ -606,16 +613,16 @@ def main() -> None:
 
             stdscr.erase()
             warning = None
-            if mqstat.parse_qstat.limit_hit or getattr(mqstat.parse_qstat, "hist_limit_hit", False):
-                parts = []
-                if mqstat.parse_qstat.limit_hit:
-                    parts.append("running/queued jobs")
-                if getattr(mqstat.parse_qstat, "hist_limit_hit", False):
-                    parts.append("finished jobs")
+            warning_parts = []
+            if mqstat.parse_qstat.limit_hit:
+                warning_parts.append("qstat -f missing running/queued jobs")
+            if getattr(mqstat.parse_qstat, "hist_limit_hit", False):
+                warning_parts.append("qstat -xf missing finished jobs")
+            if warning_parts:
                 warning = (
-                    "\x1b[91mWARNING: job list truncated; increase --max-jobs to see more "
-                    + " and ".join(parts)
-                    + "\x1b[0m"
+                    "\x1b[91mWARNING: "
+                    + " and ".join(warning_parts)
+                    + "; increase --max-jobs\x1b[0m"
                 )
             page = maxy - 3
             if lines:

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -347,6 +347,11 @@ def main() -> None:
         default=1000,
         help="Maximum number of jobs to load",
     )
+    parser.add_argument(
+        "--print-first-page",
+        action="store_true",
+        help="Print first page of job table to stdout and exit",
+    )
     args = parser.parse_args()
 
     def get_jobs(include_history: bool = False):
@@ -355,6 +360,35 @@ def main() -> None:
             include_history=include_history,
             max_jobs=args.max_jobs,
         )
+
+    if args.print_first_page:
+        jobs = get_jobs(include_history=True)
+        now = time.time()
+        finished = {}
+        running = []
+        queued = []
+        for job in jobs:
+            if job.get("queue") == "cpu_inter_exec":
+                continue
+            state = job.get("state")
+            if state in ("C", "F"):
+                ft = job.get("obittime") or job.get("mtime", now)
+                if now - ft <= 24 * 3600:
+                    finished[job["id"]] = job
+            elif state == "Q":
+                queued.append(job)
+            else:
+                running.append(job)
+        running.sort(key=lambda j: j.get("walltime_used", 0), reverse=True)
+        queued.sort(key=lambda j: now - j.get("qtime", now), reverse=True)
+        finished_jobs = sorted(
+            finished.values(), key=lambda j: j.get("obittime") or j.get("mtime", 0), reverse=True
+        )
+        all_jobs = running + queued + finished_jobs
+        lines, _ = format_jobs(all_jobs, now=now)
+        for line in lines[:24]:
+            print(line)
+        return
 
     def _draw(stdscr):
         curses.curs_set(0)

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -381,10 +381,14 @@ def main() -> None:
         refresh = True
         show_queued = True
         last_refresh = 0.0
+        user_warning = None
+        user_warn_until = 0.0
 
         while True:
             maxy, maxx = stdscr.getmaxyx()
             key = stdscr.getch()
+            if user_warning and time.time() > user_warn_until:
+                user_warning = None
             if refresh_due(last_refresh):
                 refresh = True
 
@@ -459,6 +463,12 @@ def main() -> None:
                         subprocess.call(["/pkg/hpc/scripts/ssh-to-job", str(job["id"])])
                         stdscr.clear()
                         curses.curs_set(0)
+                    else:
+                        user_warning = "Job is not running"
+                        user_warn_until = time.time() + 2
+                else:
+                    user_warning = "No job selected"
+                    user_warn_until = time.time() + 2
             elif key == ord("g"):
                 if 0 < selected <= len(job_rows):
                     job = job_rows[selected - 1]
@@ -491,6 +501,12 @@ def main() -> None:
             elif key == ord("u"):
                 show_queued = not show_queued
                 refresh = True
+            elif key not in (-1, curses.KEY_MOUSE, curses.KEY_RESIZE):
+                if 32 <= key <= 126:
+                    user_warning = f"Unknown key '{chr(key)}'"
+                else:
+                    user_warning = "Unknown key"
+                user_warn_until = time.time() + 2
 
             if refresh:
                 jobs = get_jobs(include_history=True)
@@ -528,7 +544,7 @@ def main() -> None:
             warning = None
             if mqstat.parse_qstat.limit_hit:
                 warning = "\x1b[91mWARNING: job list truncated; increase --max-jobs to see more running/queued jobs\x1b[0m"
-            page = maxy - 2
+            page = maxy - 3
             if lines:
                 max_sel = len(lines) - 1
                 selected = min(max(1, selected), max_sel)
@@ -549,10 +565,12 @@ def main() -> None:
             else:
                 offset = 0
                 selected = 1
+            if user_warning:
+                addstr_safe(stdscr, maxy - 2, 0, user_warning, maxx, curses.color_pair(2))
             help_text = (
                 "q quit  / search  o stdout  e stderr  f full  s ssh  r refresh  u toggle queued  g grafana"
             )
-            addstr_safe(stdscr, maxy - 1, 0, help_text, maxx)
+            addstr_safe(stdscr, maxy - 1, 0, help_text, maxx, curses.A_REVERSE)
             stdscr.refresh()
             time.sleep(0.1)
 

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -420,7 +420,11 @@ def main() -> None:
             curses.init_pair(4, curses.COLOR_YELLOW, -1)
         stdscr.nodelay(True)
         stdscr.keypad(True)
-        curses.mousemask(curses.BUTTON1_CLICKED)
+        curses.mousemask(
+            curses.BUTTON1_CLICKED
+            | curses.BUTTON4_PRESSED
+            | curses.BUTTON5_PRESSED
+        )
 
         finished = {}
         selected = 1  # absolute selected row index (1..)
@@ -444,12 +448,19 @@ def main() -> None:
                 break
             elif key == curses.KEY_MOUSE:
                 try:
-                    _, _, my, _, _ = curses.getmouse()
+                    _, _, my, _, bstate = curses.getmouse()
                 except curses.error:
                     pass
                 else:
-                    if 1 <= my < min(len(lines), maxy - 1):
-                        selected = min(offset + my, len(lines) - 1)
+                    if bstate & curses.BUTTON1_CLICKED:
+                        if 1 <= my < min(len(lines), maxy - 1):
+                            selected = min(offset + my, len(lines) - 1)
+                    elif bstate & curses.BUTTON4_PRESSED:
+                        if lines:
+                            selected = max(1, selected - 1)
+                    elif bstate & curses.BUTTON5_PRESSED:
+                        if lines:
+                            selected = min(selected + 1, len(lines) - 1)
             elif key in (curses.KEY_DOWN, ord("j")):
                 if lines:
                     selected = min(selected + 1, len(lines) - 1)
@@ -464,6 +475,9 @@ def main() -> None:
                 if lines:
                     page = maxy - 2
                     selected = max(1, selected - page)
+            elif key == curses.KEY_HOME:
+                selected = 1
+                offset = 0
             elif key in (ord("l"), ord("o"), ord("e")):
                 if 0 < selected <= len(job_rows):
                     job = job_rows[selected - 1]

--- a/bin/mqtop
+++ b/bin/mqtop
@@ -645,7 +645,8 @@ def main() -> None:
             )
             addstr_safe(stdscr, maxy - 1, 0, help_text, maxx, curses.A_REVERSE)
             stdscr.refresh()
-            time.sleep(0.1)
+            if key == -1:
+                time.sleep(0.1)
 
     curses.wrapper(_draw)
 

--- a/tests/data/qstat_xf_finished.txt
+++ b/tests/data/qstat_xf_finished.txt
@@ -1,0 +1,52 @@
+Job Id: 10592488.aqua
+    Job_Name = snakejobsemibin.23.sh
+    Job_Owner = woodcrob@aquarius01.ib0.hpc.qut.edu.au
+    resources_used.cpupercent = 2400
+    resources_used.cput = 415:39:01
+    resources_used.mem = 26482476kb
+    resources_used.ncpus = 24
+    resources_used.ngpus = 0
+    resources_used.vmem = 137190880kb
+    resources_used.walltime = 20:28:57
+    job_state = F
+    queue = cpu_batch_exec
+    server = aqua
+    Checkpoint = u
+    ctime = Fri Aug 22 20:30:34 2025
+    Error_Path = aquarius01.ib0.hpc.qut.edu.au:/home/woodcrob/qsub_logs/2025-08-22/snakejobsemibin.23.sh-109/
+    exec_host = cpu1n025/4*0
+    exec_vnode = (cpu1n025[0]:ncpus=11:mem=134217728kb+cpu1n025[1]:ncpus=13)
+    Hold_Types = n
+    Join_Path = n
+    Keep_Files = n
+    Mail_Points = a
+    Mail_Users = woodcrob@qut.edu.au
+    mtime = Sat Aug 23 17:33:03 2025
+    Output_Path = aquarius01.ib0.hpc.qut.edu.au:/home/woodcrob/qsub_logs/2025-08-22/snakejobsemibin.23.sh-109/
+    Priority = 0
+    qtime = Fri Aug 22 20:30:34 2025
+    Rerunable = True
+    Resource_List.cpu_id = any
+    Resource_List.mem = 128gb
+    Resource_List.ncpus = 24
+    Resource_List.nfpgas = 0
+    Resource_List.ngpus = 0
+    Resource_List.nodect = 1
+    Resource_List.place = pack
+    Resource_List.select = 1:cpu_id=any:mem=128gb:ncpus=24:nfpgas=0:ngpus=0
+    Resource_List.walltime = 24:00:00
+    stime = Fri Aug 22 21:04:04 2025
+    obittime = Sat Aug 23 17:33:03 2025
+    session_id = 56520
+    jobdir = /home/woodcrob
+    substate = 92
+    Variable_List = PBS_O_HOME=/home/woodcrob,PBS_O_LANG=en_US.UTF-8,PBS_O_LOGNAME=woodcrob,PBS_O_PATH=/mnt/hpccs01/home/woodcrob/git/binchicken/binchicken/.pixi/envs/aviary/bin:/mnt/hpccs01/home/woodcrob/git/binchicken/binchicken/.pixi/envs/default/bin:/home/woodcrob/.pixi/bin:/home/woodcrob/.cargo/bin:/home/woodcrob/bioinfo/textadept_10.8.x86_64:/home/woodcrob/bin:/home/woodcrob/git/bbbin:/home/woodcrob/git/bbbin/rust/target/release:/home/woodcrob/git/mfqe/target/release:/opt/clmgr/sbin:/opt/clmgr/bin:/opt/sgi/sbin:/opt/sgi/bin:/mnt/hpccs01/work/microbiome/sw/hpc_scripts/bin:/home/woodcrob/.cargo/bin:/home/woodcrob/.pixi/bin:/home/woodcrob/.cargo/bin:/home/woodcrob/bioinfo/textadept_10.8.x86_64:/home/woodcrob/bin:/home/woodcrob/git/bbbin:/home/woodcrob/git/bbbin/rust/target/release:/home/woodcrob/git/mfqe/target/release:/home/woodcrob/.local/bin:/home/woodcrob/bin:/opt/clmgr/sbin:/opt/clmgr/bin:/opt/sgi/sbin:/opt/sgi/bin:/mnt/weka/pkg/cmr/sw/conda/bin:/mnt/weka/pkg/cmr/sw/conda/condabin:/mnt/hpccs01/work/microbiome/sw/hpc_scripts/bin:/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/opt/c3/bin:/opt/pbs/bin:/sbin:/bin:/pkg/hpc/scripts:/opt/pbs/bin:/sbin:/bin:/pkg/hpc/scripts,PBS_O_MAIL=/var/spool/mail/woodcrob,PBS_O_SHELL=/bin/bash,PBS_O_INTERACTIVE_AUTH_METHOD=resvport,PBS_O_HOST=aquarius01.ib0.hpc.qut.edu.au,PBS_O_WORKDIR=/mnt/weka/scratch/microbiome/woodcrob/worm_binchicken/coassemble/coassemble/coassembly_18/recover,PBS_O_SYSTEM=Linux,PBS_O_QUEUE=cpu_batch,RAMDIR=/dev/shm/10592488.aqua
+    comment = Job run at Fri Aug 22 at 21:04 on (cpu1n025[0]:ncpus=11:mem=134217728kb+cpu1n025[1]:ncpus=13) and finished
+    etime = Fri Aug 22 20:30:34 2025
+    run_count = 1
+    Stageout_status = 1
+    Exit_status = 0
+    Submit_arguments = /tmp/mqsub_scriptibkm71mu.sh
+    history_timestamp = 1755934383
+    project = _pbs_project_default
+    Submit_Host = aquarius01.ib0.hpc.qut.edu.au

--- a/tests/test_mqstat.py
+++ b/tests/test_mqstat.py
@@ -149,17 +149,20 @@ def test_parse_qstat_merges_active_and_history():
 def test_parse_qstat_history_only_when_no_active_jobs():
     repo = Path(__file__).resolve().parents[1]
     script = repo / "bin" / "mqstat"
+    hist_file = repo / "tests" / "data" / "qstat_xf_finished.txt"
     import runpy
     mod = runpy.run_path(str(script))
+
+    hist_data = hist_file.read_text()
 
     def fake_run_command(cmd):
         if "qstat -f -t" in cmd:
             return ""
-        return "Job Id: 5.server\n    job_state = F\n"
+        return hist_data
 
     mod['parse_qstat'].__globals__['run_command'] = fake_run_command
     jobs = mod['parse_qstat'](include_history=True)
-    assert [j['id'] for j in jobs] == ['5.server']
+    assert [j['id'] for j in jobs] == ['10592488.aqua']
     assert jobs[0]['state'] == 'F'
 
 

--- a/tests/test_mqstat.py
+++ b/tests/test_mqstat.py
@@ -239,15 +239,17 @@ def test_job_table_warning_when_limited():
     job = {'id': '1', 'name': 'a', 'ncpus': 1, 'mem_request_gb': 1, 'state': 'R'}
     mod['parse_qstat'].limit_hit = True
     lines = mod['job_table']([job])
-    assert lines[0].startswith("\x1b[91mWARNING: job list truncated")
-    assert "running/queued jobs" in lines[0]
+    assert lines[0].startswith("\x1b[91mWARNING: qstat -f")
+    assert "running/queued" in lines[0]
     mod['parse_qstat'].limit_hit = False
     mod['parse_qstat'].hist_limit_hit = True
     lines = mod['job_table']([job])
-    assert "finished jobs" in lines[0]
+    assert lines[0].startswith("\x1b[91mWARNING: qstat -xf")
+    assert "finished" in lines[0]
     mod['parse_qstat'].limit_hit = True
     lines = mod['job_table']([job])
-    assert "running/queued jobs and finished jobs" in lines[0]
+    assert lines[0].startswith("\x1b[91mWARNING: qstat -f")
+    assert lines[1].startswith("\x1b[91mWARNING: qstat -xf")
     mod['parse_qstat'].limit_hit = False
     mod['parse_qstat'].hist_limit_hit = False
 

--- a/tests/test_mqtop.py
+++ b/tests/test_mqtop.py
@@ -15,7 +15,13 @@ def test_mqtop_print_first_page():
     script = repo / "bin" / "mqtop"
     qstat_file = repo / "tests" / "data" / "qstat_f.txt"
     result = subprocess.run(
-        [sys.executable, str(script), "--print-first-page", "--qstat-file", str(qstat_file)],
+        [
+            sys.executable,
+            str(script),
+            "--print-first-page",
+            "--qstat-f-file",
+            str(qstat_file),
+        ],
         text=True,
         capture_output=True,
         check=True,
@@ -44,3 +50,45 @@ def test_mqtop_print_first_page():
     assert "  2" in lines[1]
     assert "R      batch" in lines[1]
     assert "123.server" in lines[-1]
+
+
+def test_mqtop_history_only_print_first_page():
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "bin" / "mqtop"
+    qstat_f = repo / "tests" / "data" / "qstat_f_empty.txt"
+    qstat_xf = repo / "tests" / "data" / "qstat_xf_finished.txt"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--print-first-page",
+            "--qstat-f-file",
+            str(qstat_f),
+            "--qstat-xf-file",
+            str(qstat_xf),
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    lines = [l for l in result.stdout.splitlines() if l]
+    assert len(lines) == 2
+    header = [c for c in split_cols(lines[0]) if c]
+    assert header == [
+        "job_id",
+        "name",
+        "time used",
+        "progress",
+        "walltime",
+        "waited",
+        "age",
+        "CPU",
+        "cpu%",
+        "RAM(G)",
+        "ram%",
+        "state",
+        "queue",
+        "note",
+    ]
+    assert "10592488.aqua" in lines[1]
+    assert lines.count(lines[0]) == 1


### PR DESCRIPTION
## Summary
- Invert colour scheme for mqtop's help row
- Show a temporary warning when invalid keys are pressed or when `s` is used on non-running jobs

## Testing
- `python -m py_compile bin/mqtop`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad8414d2d4832aae706ddaf60b7ff7