### PR TITLE
Add half option to mqinteractive

### DIFF
--- a/bin/real-mqinteractive
+++ b/bin/real-mqinteractive
@@ -26,10 +26,13 @@ elif [ "$1" == "gpu" ]; then
     # NOTE: keep in sync with usual invocation below
     qsub -I -l select=1:ncpus=8:mem=32GB:ngpus=1,walltime=12:00:00
 
+elif [ "$1" == "half" ]; then
+    qsub -I -l select=1:ncpus=4:mem=16GB,walltime=12:00:00
+
 elif [ -n "$1" ]; then
     echo "Unknown argument: $1"
     exit 1
-    
+
 else
     # NOTE: keep in sync with gpu invocation above
     qsub -I -l select=1:ncpus=8:mem=32GB,walltime=12:00:00


### PR DESCRIPTION
## Summary
- add a half option to mqinteractive to request smaller interactive sessions
- set the half option to use 4 CPUs and 16GB memory

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69264e8bfc08832a840d57460e8a7093)