### PR TITLE
Retry mqsub submissions when complex limits reached

### DIFF
--- a/bin/mqsub
+++ b/bin/mqsub
@@ -237,17 +237,21 @@ class script_format:
             with open(outfile.name) as script_written:
                 logging.debug("Script written was:\n{}".format(script_written.read()))
 
+            warned_exceed_complex = False
+
             while True:
                 try:
                     qsub_stdout = run("TMPDIR={} qsub {}".format(args.script_tmpdir, outfile.name)).decode()
                     break
                 except ExternCalledProcessError as e:
                     if "qsub: would exceed complex" in e.stderr:
-                        logging.error(
-                            "qsub submission failed because it would exceed complex: %s",
-                            e.stderr.strip(),
-                        )
-                        logging.info("Waiting 60 seconds before retrying submission")
+                        if not warned_exceed_complex:
+                            logging.error(
+                                "qsub submission failed because it would exceed complex: %s",
+                                e.stderr.strip(),
+                            )
+                            logging.info("Waiting 60 seconds before retrying submission")
+                            warned_exceed_complex = True
                         time.sleep(60)
                         continue
                     raise

--- a/bin/mqsub
+++ b/bin/mqsub
@@ -237,7 +237,20 @@ class script_format:
             with open(outfile.name) as script_written:
                 logging.debug("Script written was:\n{}".format(script_written.read()))
 
-            qsub_stdout = run("TMPDIR={} qsub {}".format(args.script_tmpdir, outfile.name)).decode()
+            while True:
+                try:
+                    qsub_stdout = run("TMPDIR={} qsub {}".format(args.script_tmpdir, outfile.name)).decode()
+                    break
+                except ExternCalledProcessError as e:
+                    if "qsub: would exceed complex" in e.stderr:
+                        logging.error(
+                            "qsub submission failed because it would exceed complex: %s",
+                            e.stderr.strip(),
+                        )
+                        logging.info("Waiting 60 seconds before retrying submission")
+                        time.sleep(60)
+                        continue
+                    raise
             logging.info("qsub stdout was: {}".format(qsub_stdout.rstrip()))
             if not args.bg:
                 match_result = re.compile('^(\d+\.aqua)\n$').match(qsub_stdout)


### PR DESCRIPTION
## Summary
- add a retry loop when qsub returns "would exceed complex" so the user is notified and submission is retried after waiting
- preserve existing submission handling for other errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a38586500832ab27878d73d189921)