### PR TITLE
Format queued wait times as HH:MM in mqtop

### DIFF
--- a/bin/mqstat
+++ b/bin/mqstat
@@ -497,6 +497,7 @@ def format_hm(seconds):
     """Format seconds to HH:MM."""
     if seconds is None:
         return ""
+    seconds = int(seconds)
     h = seconds // 3600
     m = (seconds % 3600) // 60
     return f"{h:02}:{m:02}"

--- a/bin/mqsub
+++ b/bin/mqsub
@@ -237,17 +237,21 @@ class script_format:
             with open(outfile.name) as script_written:
                 logging.debug("Script written was:\n{}".format(script_written.read()))
 
+            warned_exceed_complex = False
+
             while True:
                 try:
                     qsub_stdout = run("TMPDIR={} qsub {}".format(args.script_tmpdir, outfile.name)).decode()
                     break
                 except ExternCalledProcessError as e:
                     if "qsub: would exceed complex" in e.stderr:
-                        logging.error(
-                            "qsub submission failed because it would exceed complex: %s",
-                            e.stderr.strip(),
-                        )
-                        logging.info("Waiting 60 seconds before retrying submission")
+                        if not warned_exceed_complex:
+                            logging.error(
+                                "qsub submission failed because it would exceed complex: %s",
+                                e.stderr.strip(),
+                            )
+                            logging.info("Waiting 60 seconds before retrying submission")
+                            warned_exceed_complex = True
                         time.sleep(60)
                         continue
                     raise

--- a/bin/mqsub
+++ b/bin/mqsub
@@ -237,7 +237,20 @@ class script_format:
             with open(outfile.name) as script_written:
                 logging.debug("Script written was:\n{}".format(script_written.read()))
 
-            qsub_stdout = run("TMPDIR={} qsub {}".format(args.script_tmpdir, outfile.name)).decode()
+            while True:
+                try:
+                    qsub_stdout = run("TMPDIR={} qsub {}".format(args.script_tmpdir, outfile.name)).decode()
+                    break
+                except ExternCalledProcessError as e:
+                    if "qsub: would exceed complex" in e.stderr:
+                        logging.error(
+                            "qsub submission failed because it would exceed complex: %s",
+                            e.stderr.strip(),
+                        )
+                        logging.info("Waiting 60 seconds before retrying submission")
+                        time.sleep(60)
+                        continue
+                    raise
             logging.info("qsub stdout was: {}".format(qsub_stdout.rstrip()))
             if not args.bg:
                 match_result = re.compile('^(\d+\.aqua)\n$').match(qsub_stdout)


### PR DESCRIPTION
### Motivation
- Queued jobs were being displayed with values like `0.0:0.0` instead of `00:00` because `format_hm` was operating on non-integer seconds. 
- The intent is to make queued job wait times render consistently with other job time fields. 

### Description
- Coerce `seconds` to an integer in `bin/mqstat` by adding `seconds = int(seconds)` at the start of `format_hm`. 
- This ensures `format_hm` produces zero-padded `HH:MM` output for float or numeric inputs used by `mqtop`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962009c7f88832a93daae06700524e8)